### PR TITLE
BtnWrapper 경로 수정 및 적용

### DIFF
--- a/lubee/src/@styles/btnStyle.ts
+++ b/lubee/src/@styles/btnStyle.ts
@@ -1,4 +1,4 @@
-import { css } from "styled-components";
+import { styled, css } from "styled-components";
 
 /*로그인 페이지, 온보딩 페이지 버튼 스타일*/
 export const btnOnboardingStyle = css`
@@ -8,4 +8,11 @@ export const btnOnboardingStyle = css`
   border-radius: 10px;
 
   ${({ theme }) => theme.fonts.Title_1};
+`;
+
+export const BtnWrapper = styled.button`
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
 `;

--- a/lubee/src/@styles/globalStyle.ts
+++ b/lubee/src/@styles/globalStyle.ts
@@ -1,17 +1,10 @@
-import styled, { createGlobalStyle, css } from "styled-components";
+import { createGlobalStyle, css } from "styled-components";
 import reset from "styled-reset";
 
 export const flexCenter = css`
   display: flex;
   justify-content: center;
   align-items: center;
-`;
-
-export const BtnWrapper = styled.button`
-  padding: 0;
-  border: none;
-  background: none;
-  cursor: pointer;
 `;
 
 export const GlobalStyle = createGlobalStyle`

--- a/lubee/src/fullpic/components/FullpicHeader.tsx
+++ b/lubee/src/fullpic/components/FullpicHeader.tsx
@@ -1,4 +1,5 @@
 import { BackIc, TrashIc } from "@assets/index";
+import { BtnWrapper } from "@styles/btnStyle";
 import styled from "styled-components";
 
 interface FullpicHeaderProps {
@@ -45,11 +46,4 @@ const Date = styled.p`
 const TrashIcon = styled(TrashIc)`
   width: 2.4rem;
   height: 2.4rem;
-`;
-
-const BtnWrapper = styled.button`
-  padding: 0;
-  border: none;
-  background: none;
-  cursor: pointer;
 `;

--- a/lubee/src/home/components/HomeFooter.tsx
+++ b/lubee/src/home/components/HomeFooter.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { ExploreDeactivateIc, HomeActivateIc, MyDeactivateIc } from "@assets/index";
+import { BtnWrapper } from "@styles/btnStyle";
 
 export default function HomeFooter() {
   const navigate = useNavigate();
@@ -73,14 +74,6 @@ const ActivateText = styled.p`
   ${({ theme }) => theme.fonts.Caption_0};
 
   color: ${({ theme }) => theme.colors.gray_600};
-`;
-
-const BtnWrapper = styled.button`
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  justify-content: center;
-  align-items: center;
 `;
 
 const MyDeactivateIcon = styled(MyDeactivateIc)`

--- a/lubee/src/mypage/components/MypageFooter.tsx
+++ b/lubee/src/mypage/components/MypageFooter.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { ExploreDeactivateIc, HomeDeactivateIc, MyActivateIc } from "@assets/index";
+import { BtnWrapper } from "@styles/btnStyle";
 
 export default function MypageFooter() {
   const navigate = useNavigate();
@@ -62,14 +63,6 @@ const Container = styled.div`
   width: 100%;
   padding: 1.1rem 9.4rem 0;
   background-color: ${({ theme }) => theme.colors.white};
-`;
-
-const BtnWrapper = styled.button`
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  justify-content: center;
-  align-items: center;
 `;
 
 const DeactivateText = styled.p`

--- a/lubee/src/onboarding/custom/index.tsx
+++ b/lubee/src/onboarding/custom/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import Header from "../components/Header";
 import Profiles from "../components/Profiles";
+import { BtnWrapper } from "@styles/btnStyle";
 
 export default function index() {
   const navigate = useNavigate();
@@ -45,13 +46,6 @@ const ProfileGrid = styled.section`
   grid-template-columns: repeat(2, 1fr);
   gap: 2rem 3.6rem;
   justify-items: center;
-`;
-
-const BtnWrapper = styled.button`
-  padding: 0;
-  border: none;
-  background: none;
-  cursor: pointer;
 `;
 
 const ProfileIcon = styled.svg`

--- a/lubee/src/onboarding/index.tsx
+++ b/lubee/src/onboarding/index.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { useState } from "react";
 import { LubeeCodeIc, CopyIc } from "@assets/index";
 import { btnOnboardingStyle } from "@styles/btnStyle";
-import { BtnWrapper } from "@styles/globalStyle";
+import { BtnWrapper } from "@styles/btnStyle";
 import Header from "./components/Header";
 import TitleBox from "./components/TitleBox";
 import YellowBox from "./components/YellowBox";
@@ -53,7 +53,7 @@ export default function index() {
       <LubeeCodeIcon />
       <MyCodeContainer>
         <MyCodeText>나의 러비코드</MyCodeText>
-        <BtnWrapper onClick={handleInviteClick}>
+        <BtnWrapper type="button" onClick={handleInviteClick}>
           <YellowBox $disabled={false}>
             12345 67890
             <CopyIcon />

--- a/lubee/src/onboarding/profile/index.tsx
+++ b/lubee/src/onboarding/profile/index.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import styled from "styled-components";
 import { Profile1Ic } from "@assets/index";
-import { BtnWrapper } from "@styles/globalStyle";
+import { BtnWrapper } from "@styles/btnStyle";
 import Header from "../components/Header";
 import ProgressBar from "../components/ProgressBar";
 import TitleBox from "../components/TitleBox";

--- a/lubee/src/upload/components/SelectLocationModal.tsx
+++ b/lubee/src/upload/components/SelectLocationModal.tsx
@@ -1,6 +1,7 @@
 import { SearchIc, XIc } from "@assets/index";
 import { locationData } from "@common/core/locationData";
 import styled from "styled-components";
+import { BtnWrapper } from "@styles/btnStyle";
 
 interface SelectLocationModalProps {
   setOpenLocationModal: (open: boolean) => void;
@@ -120,13 +121,6 @@ const SearchButton = styled.button`
 const SearchIcon = styled(SearchIc)`
   width: 2.4rem;
   height: 2.4rem;
-`;
-
-const BtnWrapper = styled.button`
-  padding: 0;
-  border: none;
-  background: none;
-  cursor: pointer;
 `;
 
 const Locations = styled.div`

--- a/lubee/src/upload/location/index.tsx
+++ b/lubee/src/upload/location/index.tsx
@@ -4,6 +4,7 @@ import { SearchIc } from "@assets/index";
 import { locationData } from "@common/core/locationData";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { BtnWrapper } from "@styles/btnStyle";
 
 interface LocationProps {
   setLocation: (location: string) => void;
@@ -87,13 +88,6 @@ const Header = styled.div`
 const BackIcon = styled(BackIc)`
   width: 2.4rem;
   height: 2.4rem;
-`;
-
-const BtnWrapper = styled.button`
-  padding: 0;
-  border: none;
-  background: none;
-  cursor: pointer;
 `;
 
 const Text = styled.div`

--- a/lubee/src/upload/pic/index.tsx
+++ b/lubee/src/upload/pic/index.tsx
@@ -4,7 +4,7 @@ import fullPic from "@assets/image/fullPic.png";
 import FullPicContainer from "@common/components/FullPicContainer";
 import { useState } from "react";
 import SelectLocationModal from "upload/components/SelectLocationModal";
-
+import { BtnWrapper } from "@styles/btnStyle";
 interface UploadProps {
   // picSrc: string;
   location: string;
@@ -57,13 +57,6 @@ const Header = styled.div`
 const BackIcon = styled(BackIc)`
   width: 2.4rem;
   height: 2.4rem;
-`;
-
-const BtnWrapper = styled.button`
-  padding: 0;
-  border: none;
-  background: none;
-  cursor: pointer;
 `;
 
 const Footer = styled.div`


### PR DESCRIPTION
## Related Issues

- close #15 

## PR 유형

어떤 변경 사항이 있나요?

- [x] CSS 등 스타일 변경

## 변경 사항 in Detail

- [x] BtnWrapper 경로 수정
  - @ styles>btnStyle.ts에 혜연이가 만들어둔거 옮겨놨어 !
```js
export const BtnWrapper = styled.button`
  padding: 0;
  border: none;
  background: none;
  cursor: pointer;
`;
```
- [x] 공통 컴포넌트 BtnWrapper 로 코드 리팩토링
- [x] BtnWrapper에 styled.button이라고 되어있지만 가져다 쓸 때 `type="button"` 잊지 않고 명시해주기!
`<BtnWrapper type="button" onClick={handleInviteClick}></BtnWrapper>`

## 저번 pr 피드백
<img width="639" alt="스크린샷 2024-07-12 오전 11 29 35" src="https://github.com/user-attachments/assets/859b94e6-20e6-4118-8408-9f3611cf84e8">

## 다음에 할 것 
- 슬슬 로직에 문제 없는지 props 전달이랑 그런 것들 리팩토링 
- 마이페이지랑 축하페이지 뷰 역할 분담
- 이모지 반응 남긴거 디자인 fix 