### PR TITLE
헤더에 토큰이 안담기는 문제 해결

### DIFF
--- a/lubee/src/settings/hooks/useSetInterceptors.ts
+++ b/lubee/src/settings/hooks/useSetInterceptors.ts
@@ -1,18 +1,18 @@
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 
 import api from "@common/api/api";
 
 import { getToken } from "login/utils/token";
 
 const useSetInterceptors = () => {
-  useEffect(() => {
+  useLayoutEffect(() => {
     api.interceptors.request.use((config) => {
       const accessToken = getToken();
       if (accessToken) {
-        config.headers["Authorization"] = accessToken;
+        config.headers["Authorization"] = `Bearer ${accessToken}`;
       }
       return config;
     });
-  }, []);
+  });
 };
 export default useSetInterceptors;


### PR DESCRIPTION
## Related Issues

- close #78 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 오류 수정

## 변경 사항 in Detail
```js
import { useLayoutEffect } from "react";

import api from "@common/api/api";

import { getToken } from "login/utils/token";

const useSetInterceptors = () => {
  useLayoutEffect(() => {
    api.interceptors.request.use((config) => {
      const accessToken = getToken();
      if (accessToken) {
        config.headers["Authorization"] = `Bearer ${accessToken}`;
      }
      return config;
    });
  });
};
export default useSetInterceptors;
```
- [x] Bearer 추가
  - 서버에서 Bearer를 빼고 주어야 우리가 `Bearer ${accessToken}`로 처리가 가능해짐
- [x] useEffect 대신 useLayoutEffect로 수정
   - 너무 기본적인 건데 500이라서 서버이슈만있을거라고 생각했다.. 정말 미안해ㅜㅜ

## 다음에 할 것

- [ ] 커플연결 확인
- [x] #59 
