### PR TITLE
Feat/#81/onboarding/couple toast

### DIFF
--- a/lubee/src/@common/components/BigEmojiIcons.tsx
+++ b/lubee/src/@common/components/BigEmojiIcons.tsx
@@ -10,7 +10,7 @@ import {
   MintHoneyIc,
   MintSmileIc,
   MintThumbIc,
-} from "@assets/index";
+} from "assets/index";
 
 export const YellowHeartBigIcon = styled(YellowHeartIc)`
   width: 3.48rem;

--- a/lubee/src/@common/components/LocationTag.tsx
+++ b/lubee/src/@common/components/LocationTag.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { LocationPointIc, LocationPointSmallIc } from "@assets/index";
+import { LocationPointIc, LocationPointSmallIc } from "assets/index";
 
 interface LocationProps {
   location: string;

--- a/lubee/src/@common/core/emojisData.ts
+++ b/lubee/src/@common/core/emojisData.ts
@@ -9,7 +9,7 @@ import {
   MintHoneyIc,
   MintSmileIc,
   MintThumbIc,
-} from "@assets/index";
+} from "assets/index";
 import { EmojisDataTypes } from "@common/types/CommonTypes";
 
 export const emojisData: EmojisDataTypes[] = [

--- a/lubee/src/@common/core/fullPicData.ts
+++ b/lubee/src/@common/core/fullPicData.ts
@@ -1,4 +1,4 @@
-import fullPic from "@assets/image/fullPic.png";
+import fullPic from "assets/image/fullPic.png";
 import { FullPicDataTypes } from "@common/types/CommonTypes";
 
 export const fullPicData: FullPicDataTypes[] = [

--- a/lubee/src/@common/core/profileIconsData.ts
+++ b/lubee/src/@common/core/profileIconsData.ts
@@ -17,7 +17,7 @@ import {
   ProfileStroke4Ic,
   ProfileStroke5Ic,
   ProfileStroke6Ic,
-} from "@assets/index";
+} from "assets/index";
 import {
   MintProfile1Ic,
   MintProfile2Ic,
@@ -25,7 +25,7 @@ import {
   MintProfile4Ic,
   MintProfile5Ic,
   MintProfile6Ic,
-} from "@assets/index";
+} from "assets/index";
 import { ProfileIconDataTypes } from "@common/types/CommonTypes";
 
 export const profileIconsData: ProfileIconDataTypes[] = [

--- a/lubee/src/@common/hooks/useGetCouplesInfo.ts
+++ b/lubee/src/@common/hooks/useGetCouplesInfo.ts
@@ -2,10 +2,10 @@ import { useQuery } from "react-query";
 import { getCouplesInfo } from "@common/api/getCouplesInfo";
 
 export function useGetCouplesInfo() {
-  const { data } = useQuery("getCouplesInfo", () => getCouplesInfo(), {
+  const { data, isLoading, error } = useQuery("getCouplesInfo", getCouplesInfo, {
     onError: (error) => {
       console.log("에러 발생", error);
     },
   });
-  return data;
+  return { data, isLoading, error };
 }

--- a/lubee/src/@common/utils/getHoverProfileIconSrc.ts
+++ b/lubee/src/@common/utils/getHoverProfileIconSrc.ts
@@ -1,6 +1,5 @@
 import { profileIconsData } from "@common/core/profileIconsData";
-import blankImg from "@assets/image/blankImg.png";
-
+import blankImg from "assets/image/blankImg.png";
 const getHoverProfileIconSrc = (account: string, emoji: string) => {
   const accountData = profileIconsData.find((data) => data.account === account);
   if (accountData) {

--- a/lubee/src/@common/utils/getProfileIconSrc.ts
+++ b/lubee/src/@common/utils/getProfileIconSrc.ts
@@ -1,13 +1,13 @@
 import { profileIconsData } from "@common/core/profileIconsData";
-import blankImg from "@assets/image/blankImg.png";
+import { XIc } from "assets";
 
 const getProfileIconSrc = (account: string, emoji: string) => {
   const accountData = profileIconsData.find((data) => data.account === account);
   if (accountData) {
     const iconData = accountData.profileIcon.find((icon) => icon.emoji === emoji);
-    return iconData ? iconData.iconSrc : blankImg;
+    return iconData ? iconData.iconSrc : XIc;
   }
-  return blankImg;
+  return XIc;
 };
 
 export default getProfileIconSrc;

--- a/lubee/src/congrats/fifth/index.tsx
+++ b/lubee/src/congrats/fifth/index.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { CongratsIc, FifthHoneyIc } from "@assets/index";
+import { CongratsIc, FifthHoneyIc } from "assets/index";
 import CongratsTitleBox from "congrats/components/CongratsTitleBox";
 
 export default function index() {

--- a/lubee/src/congrats/first/index.tsx
+++ b/lubee/src/congrats/first/index.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { FirstHoneyIc } from "@assets/index";
+import { FirstHoneyIc } from "assets/index";
 import CongratsTitleBox from "congrats/components/CongratsTitleBox";
 
 export default function index() {

--- a/lubee/src/congrats/index.tsx
+++ b/lubee/src/congrats/index.tsx
@@ -7,8 +7,9 @@ import { infoToast } from "@common/utils/toast";
 
 export default function index() {
   const navigate = useNavigate();
-  const couplesInfoResponse = useGetCouplesInfo();
+  const { data: couplesInfoResponse } = useGetCouplesInfo();
   console.log("커플정보를 얻을 수 있는지 확인 ", couplesInfoResponse?.success);
+  console.log(couplesInfoResponse);
 
   function handleOnboardingBtn() {
     if (couplesInfoResponse?.success) {

--- a/lubee/src/congrats/index.tsx
+++ b/lubee/src/congrats/index.tsx
@@ -2,12 +2,21 @@ import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { Outlet } from "react-router-dom";
 import OnboardingBtn from "onboarding/components/OnboardingBtn";
+import { useGetCouplesInfo } from "@common/hooks/useGetCouplesInfo";
+import { infoToast } from "@common/utils/toast";
 
 export default function index() {
   const navigate = useNavigate();
+  const couplesInfoResponse = useGetCouplesInfo();
+  console.log("커플정보를 얻을 수 있는지 확인 ", couplesInfoResponse?.success);
 
   function handleOnboardingBtn() {
-    navigate("/home/today");
+    if (couplesInfoResponse?.success) {
+      // 둘다 온보딩 post를 날려서 커플정보를 얻을 수 있는 경우
+      navigate("/home/today");
+    } else {
+      infoToast("연인이 커플정보를 입력하지 않았어요!");
+    }
   }
 
   return (

--- a/lubee/src/congrats/join/index.tsx
+++ b/lubee/src/congrats/join/index.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { CongratIc, CompleteIc } from "@assets/index";
+import { CongratIc, CompleteIc } from "assets/index";
 import CongratsTitleBox from "congrats/components/CongratsTitleBox";
 
 export default function index() {

--- a/lubee/src/fullpic/components/EmojiDetailModal.tsx
+++ b/lubee/src/fullpic/components/EmojiDetailModal.tsx
@@ -1,4 +1,4 @@
-import { ShortBorderIc } from "@assets/index";
+import { ShortBorderIc } from "assets/index";
 import styled from "styled-components";
 import { forwardRef } from "react";
 import getEmojiSrc from "@common/utils/getEmojiSrc";

--- a/lubee/src/fullpic/components/FullpicHeader.tsx
+++ b/lubee/src/fullpic/components/FullpicHeader.tsx
@@ -1,4 +1,4 @@
-import { BackIc, TrashIc } from "@assets/index";
+import { BackIc, TrashIc } from "assets/index";
 import { BtnWrapper } from "@styles/btnStyle";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";

--- a/lubee/src/home/components/BlankImgBtn.tsx
+++ b/lubee/src/home/components/BlankImgBtn.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import blankImg from "@assets/image/blankImg.png";
+import blankImg from "assets/image/blankImg.png";
 import { useState, useRef } from "react";
 import { readPic } from "home/utils/readPic";
 import { useNavigate } from "react-router-dom";

--- a/lubee/src/home/components/HomeFooter.tsx
+++ b/lubee/src/home/components/HomeFooter.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
-import { ExploreDeactivateIc, HomeActivateIc, MyDeactivateIc } from "@assets/index";
+import { ExploreDeactivateIc, HomeActivateIc, MyDeactivateIc } from "assets/index";
 import { BtnWrapper } from "@styles/btnStyle";
 import { infoToast } from "@common/utils/toast";
 

--- a/lubee/src/home/components/MyCommentModal.tsx
+++ b/lubee/src/home/components/MyCommentModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import styled from "styled-components";
-import { CheckIc, CheckYellowIc, PencilIc, EditXIc } from "@assets/index";
+import { CheckIc, CheckYellowIc, PencilIc, EditXIc } from "assets/index";
 import { BtnWrapper } from "@styles/btnStyle";
 import { CommentModalProps } from "home/today/types/CommentModalTypes";
 import { usePostDateComment } from "home/hooks/usePostDateComment";

--- a/lubee/src/home/components/PartnerCommentModal.tsx
+++ b/lubee/src/home/components/PartnerCommentModal.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { EditXIc } from "@assets/index";
+import { EditXIc } from "assets/index";
 import { BtnWrapper } from "@styles/btnStyle";
 import { CommentModalProps } from "home/today/types/CommentModalTypes";
 

--- a/lubee/src/home/month/components/CalContainer.tsx
+++ b/lubee/src/home/month/components/CalContainer.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { CalInfoTypes } from "../types/CalInfoTypes";
-import { HoneyMonthIc } from "@assets/index";
+import { HoneyMonthIc } from "assets/index";
 import DateDetailModal from "./DateDetailModal";
 import { useEffect, useRef, useState } from "react";
 import { formatMonth, getTodayDate, getTodayMonth, getTodayYear, isFutureDate } from "@common/utils/dateFormat";

--- a/lubee/src/home/month/components/DateDetailModal.tsx
+++ b/lubee/src/home/month/components/DateDetailModal.tsx
@@ -1,4 +1,4 @@
-import { ShortBorderIc } from "@assets/index";
+import { ShortBorderIc } from "assets/index";
 import styled from "styled-components";
 import { forwardRef } from "react";
 import getProfileIconSrc from "@common/utils/getProfileIconSrc";

--- a/lubee/src/home/month/components/MonthPicBox.tsx
+++ b/lubee/src/home/month/components/MonthPicBox.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import BlankImgBtn from "home/components/BlankImgBtn";
-import blankImg from "@assets/image/blankImg.png";
+import blankImg from "assets/image/blankImg.png";
 import getProfileIconSrc from "@common/utils/getProfileIconSrc";
 import LocationTag from "@common/components/LocationTag";
 import EmojiTag from "@common/components/EmojiTag";

--- a/lubee/src/home/today/components/HoneyIconContainer.tsx
+++ b/lubee/src/home/today/components/HoneyIconContainer.tsx
@@ -1,12 +1,5 @@
 import styled from "styled-components";
-import {
-  TodayHoney0Ic,
-  TodayHoney1Ic,
-  TodayHoney2Ic,
-  TodayHoney3Ic,
-  TodayHoney4Ic,
-  TodayHoney5Ic,
-} from "@assets/index";
+import { TodayHoney0Ic, TodayHoney1Ic, TodayHoney2Ic, TodayHoney3Ic, TodayHoney4Ic, TodayHoney5Ic } from "assets/index";
 
 interface HoneyIconContainerProps {
   honey: number;

--- a/lubee/src/home/today/components/TodayPicBox.tsx
+++ b/lubee/src/home/today/components/TodayPicBox.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import BlankImgBtn from "home/components/BlankImgBtn";
-import blankImg from "@assets/image/blankImg.png";
+import blankImg from "assets/image/blankImg.png";
 import getProfileIconSrc from "@common/utils/getProfileIconSrc";
 import LocationTag from "@common/components/LocationTag";
 import EmojiTag from "@common/components/EmojiTag";

--- a/lubee/src/home/today/components/Toggle.tsx
+++ b/lubee/src/home/today/components/Toggle.tsx
@@ -1,4 +1,4 @@
-import { ToggleHoneyIc, TogglePastIc } from "@assets/index";
+import { ToggleHoneyIc, TogglePastIc } from "assets/index";
 import styled from "styled-components";
 import { useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";

--- a/lubee/src/home/today/components/ToggleCalendar.tsx
+++ b/lubee/src/home/today/components/ToggleCalendar.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { CAL } from "@common/core/calendarData";
 import CalContainer from "home/month/components/CalContainer";
 import { BtnWrapper } from "@styles/btnStyle";
-import { BackSmallIc, ForwardIc } from "@assets/index";
+import { BackSmallIc, ForwardIc } from "assets/index";
 import { getTodayMonth, getTodayYear } from "@common/utils/dateFormat";
 
 interface ToggleCalendarProps {

--- a/lubee/src/home/today/index.tsx
+++ b/lubee/src/home/today/index.tsx
@@ -3,7 +3,7 @@ import DateBox from "./components/DateBox";
 import TodayTitle from "./components/TodayTitle";
 import HoneyIconContainer from "./components/HoneyIconContainer";
 import TodayProfileBox from "./components/TodayProfileBox";
-import { PlusIc, PlusClickedIc } from "@assets/index";
+import { PlusIc, PlusClickedIc } from "assets/index";
 import { useState } from "react";
 import Toggle from "./components/Toggle";
 import ToggleCalendar from "./components/ToggleCalendar";

--- a/lubee/src/login/hooks/usePostLogin.ts
+++ b/lubee/src/login/hooks/usePostLogin.ts
@@ -8,36 +8,45 @@ import { useGetCouplesInfo } from "@common/hooks/useGetCouplesInfo";
 const usePostLogin = () => {
   const KAKAO_CODE = new URL(window.location.href).searchParams.get("code");
   const navigate = useNavigate();
-  const couplesInfoResponse = useGetCouplesInfo();
+  const { data: couplesInfoResponse, isLoading, error } = useGetCouplesInfo();
 
   useEffect(() => {
-    api
-      .post(`api/users/kakao/simpleLogin?code=${KAKAO_CODE}`)
-      .then((res) => {
-        const data = res.data as loginResProps; // AxiosResponse의 data를 loginResProps로 단언
-        setToken(data.response.accessToken);
-        console.log("로그인 성공");
-        console.log("로그인 데이터", data);
-        console.log("커플정보 얻기", couplesInfoResponse?.success);
-        if (couplesInfoResponse?.success) {
-          // 로그인 완료되고 온보딩까지 마친 유저의 경우 home/today로 이동
-          navigate("/home/today");
-        } else {
-          // 로그인 완료되고 온보딩이 처음인 유저의 경우 onboarding으로 이동
-          navigate("/onboarding");
-        }
-      })
-      .catch((err) => {
-        const errorData = err.response.data as loginErrorProps; // 에러 응답 데이터 단언
-        if (errorData.success_or_error_code.status === 404) {
-          setToken(errorData.response.accessToken);
-          navigate("/onboarding");
-        } else {
-          navigate("/error");
-          console.log(KAKAO_CODE);
-        }
-      });
-  }, []);
+    if (KAKAO_CODE) {
+      api
+        .post(`api/users/kakao/simpleLogin?code=${KAKAO_CODE}`)
+        .then((res) => {
+          const data = res.data as loginResProps; // AxiosResponse의 data를 loginResProps로 단언
+          setToken(data.response.accessToken);
+          console.log("로그인 성공");
+          console.log("로그인 데이터", data);
+        })
+        .catch((err) => {
+          const errorData = err.response.data as loginErrorProps; // 에러 응답 데이터 단언
+          if (errorData.success_or_error_code.status === 404) {
+            setToken(errorData.response.accessToken);
+            navigate("/onboarding");
+          } else {
+            navigate("/error");
+            console.log(KAKAO_CODE);
+          }
+        });
+    }
+  }, [KAKAO_CODE, navigate]);
+
+  useEffect(() => {
+    if (!isLoading && couplesInfoResponse) {
+      console.log("커플정보 얻기", couplesInfoResponse.success);
+      if (couplesInfoResponse.success) {
+        console.log(couplesInfoResponse);
+        navigate("/home/today");
+      } else {
+        navigate("/onboarding");
+      }
+    } else if (!isLoading && error) {
+      console.log("커플 정보 가져오기 실패", error);
+      navigate("/error");
+    }
+  }, [isLoading, couplesInfoResponse, error, navigate]);
 };
 
 export default usePostLogin;

--- a/lubee/src/login/index.tsx
+++ b/lubee/src/login/index.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { LogoIc, SymbolLoginIc } from "@assets/index";
+import { LogoIc, SymbolLoginIc } from "assets/index";
 import { btnOnboardingStyle } from "@styles/btnStyle";
 import CompanyText from "@common/components/CompanyText";
 import { KAKAO_LINK } from "./constants/kakaoLink";

--- a/lubee/src/mypage/components/AlbumsContainer.tsx
+++ b/lubee/src/mypage/components/AlbumsContainer.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import MypageBlankImgBtn from "./MypageBlankImgBtn";
-import album1Img from "@assets/image/album1Img.png";
-import album2Img from "@assets/image/album2Img.png";
+import album1Img from "assets/image/album1Img.png";
+import album2Img from "assets/image/album2Img.png";
 
 export default function AlbumsContainer() {
   return (

--- a/lubee/src/mypage/components/Banner.tsx
+++ b/lubee/src/mypage/components/Banner.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { BannerIc, NextIc } from "@assets/index";
+import { BannerIc, NextIc } from "assets/index";
 
 export default function Banner() {
   return (

--- a/lubee/src/mypage/components/HoneyBox.tsx
+++ b/lubee/src/mypage/components/HoneyBox.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { HoneyYellowIc, PlayIc } from "@assets/index";
+import { HoneyYellowIc, PlayIc } from "assets/index";
 import RewindBtn from "./RewindBtn";
 
 interface HoneyBoxProps {

--- a/lubee/src/mypage/components/MypageBlankImgBtn.tsx
+++ b/lubee/src/mypage/components/MypageBlankImgBtn.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import blankImg from "@assets/image/blankImg.png";
+import blankImg from "assets/image/blankImg.png";
 import { useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/lubee/src/mypage/components/MypageFooter.tsx
+++ b/lubee/src/mypage/components/MypageFooter.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
-import { ExploreDeactivateIc, HomeDeactivateIc, MyActivateIc } from "@assets/index";
+import { ExploreDeactivateIc, HomeDeactivateIc, MyActivateIc } from "assets/index";
 import { BtnWrapper } from "@styles/btnStyle";
 import { infoToast } from "@common/utils/toast";
 

--- a/lubee/src/mypage/components/MypageProfileBox.tsx
+++ b/lubee/src/mypage/components/MypageProfileBox.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { XIc, EditIc } from "@assets/index";
+import { XIc, EditIc } from "assets/index";
 import getHoverProfileIconSrc from "@common/utils/getHoverProfileIconSrc";
 
 interface MypageProfileBoxProps {

--- a/lubee/src/mypage/components/RewindBtn.tsx
+++ b/lubee/src/mypage/components/RewindBtn.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { RewindIc } from "@assets/index";
+import { RewindIc } from "assets/index";
 
 export default function RewindBtn() {
   return (

--- a/lubee/src/mypage/components/SaveContainer.tsx
+++ b/lubee/src/mypage/components/SaveContainer.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
-import collectImg from "@assets/image/collectImg.png";
-import collect2Img from "@assets/image/collect2Img.png";
-import collect3Img from "@assets/image/collect3Img.png";
+import collectImg from "assets/image/collectImg.png";
+import collect2Img from "assets/image/collect2Img.png";
+import collect3Img from "assets/image/collect3Img.png";
 
 export default function AlbumContainer() {
   return (

--- a/lubee/src/mypage/index.tsx
+++ b/lubee/src/mypage/index.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import MypageFooter from "./components/MypageFooter";
-import { SettingIc } from "@assets/index";
+import { SettingIc } from "assets/index";
 import MypageProfileBox from "./components/MypageProfileBox";
 import HoneyBox from "./components/HoneyBox";
 import Banner from "./components/Banner";

--- a/lubee/src/onboarding/complete/index.tsx
+++ b/lubee/src/onboarding/complete/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import { CongratIc, CompleteIc } from "@assets/index";
+import { CongratIc, CompleteIc } from "assets/index";
 import TitleBox from "congrats/components/CongratsTitleBox";
 import OnboardingBtn from "../components/OnboardingBtn";
 

--- a/lubee/src/onboarding/components/OnboardingHeader.tsx
+++ b/lubee/src/onboarding/components/OnboardingHeader.tsx
@@ -1,4 +1,4 @@
-import { BackIc, XIc } from "@assets/index";
+import { BackIc, XIc } from "assets/index";
 import styled from "styled-components";
 
 interface OnboardingHeaderProps {

--- a/lubee/src/onboarding/components/ProgressBar.tsx
+++ b/lubee/src/onboarding/components/ProgressBar.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { ProgressBar1Ic, ProgressBar2Ic, ProgressBar3Ic, ProgressBar4Ic } from "@assets/index";
+import { ProgressBar1Ic, ProgressBar2Ic, ProgressBar3Ic, ProgressBar4Ic } from "assets/index";
 
 interface ProgressBarProps {
   step: number;

--- a/lubee/src/onboarding/connect/index.tsx
+++ b/lubee/src/onboarding/connect/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { LubeeCodeIc, CopyIc } from "@assets/index";
 import { btnOnboardingStyle } from "@styles/btnStyle";
 import { BtnWrapper } from "@styles/btnStyle";
@@ -9,14 +9,43 @@ import OnboardingTitleBox from "../components/OnboardingTitleBox";
 import YellowBox from "../components/YellowBox";
 import CopyCodeModal from "../components/CopyCodeModal";
 import { useGetLubeeCode } from "onboarding/hooks/useGetLubeeCode";
+import { infoToast } from "@common/utils/toast";
+
 interface ConnectProps {
   moveToOnboardingCode: () => void;
+  moveToOnboardingCustom: () => void;
 }
 
 export default function index(props: ConnectProps) {
-  const { moveToOnboardingCode } = props;
+  const { moveToOnboardingCode, moveToOnboardingCustom } = props;
   const navigate = useNavigate();
   const [openCopyCodeModal, setOpenCopyCodeModal] = useState<boolean>(false);
+  const [lubeeCode, setLubeeCode] = useState<any>(null);
+
+  // useGetLubeeCode 훅을 사용한 상태 업데이트
+  const fetchedLubeeCode = useGetLubeeCode();
+
+  useEffect(() => {
+    // lubeeCode 값이 변경될 때마다 상태 업데이트
+    if (fetchedLubeeCode) {
+      setLubeeCode(fetchedLubeeCode);
+    }
+  }, [fetchedLubeeCode]);
+
+  useEffect(() => {
+    if (lubeeCode?.response?.code === "ALREADY_COUPLE") {
+      infoToast("이미 커플로 등록된 상태입니다.");
+      setTimeout(() => {
+        moveToOnboardingCustom();
+      }, 2000);
+    }
+  }, [lubeeCode, moveToOnboardingCustom]);
+
+  if (!lubeeCode) return <></>;
+
+  const {
+    response: { code },
+  } = lubeeCode;
 
   function handleXBtn() {
     navigate("/login");
@@ -57,13 +86,6 @@ export default function index(props: ConnectProps) {
   function handleOnboardingBtn() {
     moveToOnboardingCode();
   }
-
-  const lubeeCode = useGetLubeeCode();
-  if (!lubeeCode) return <></>;
-
-  const {
-    response: { code },
-  } = lubeeCode;
 
   return (
     <Wrapper>

--- a/lubee/src/onboarding/connect/index.tsx
+++ b/lubee/src/onboarding/connect/index.tsx
@@ -71,7 +71,7 @@ export default function index(props: ConnectProps) {
       try {
         await navigator.share({
           title: "연인으로부터 러비 초대장이 도착했어요! 링크를 눌러 초대장을 받아주세요.",
-          text: "연인으로부터 러비 초대장이 도착했어요!\n링크를 눌러 초대장을 받아주세요.\n연인의 러비코드: 1234 5678",
+          text: `연인으로부터 러비 초대장이 도착했어요!\n링크를 눌러 초대장을 받아주세요.\n연인의 러비코드: ${code}`,
           url: "https://example.com", // 실제 공유할 URL로 변경
         });
         console.log("공유 성공");

--- a/lubee/src/onboarding/connect/index.tsx
+++ b/lubee/src/onboarding/connect/index.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { useState, useEffect } from "react";
-import { LubeeCodeIc, CopyIc } from "@assets/index";
+import { LubeeCodeIc, CopyIc } from "assets/index";
 import { btnOnboardingStyle } from "@styles/btnStyle";
 import { BtnWrapper } from "@styles/btnStyle";
 import OnboardingHeader from "../components/OnboardingHeader";

--- a/lubee/src/onboarding/index.tsx
+++ b/lubee/src/onboarding/index.tsx
@@ -78,7 +78,9 @@ export default function index() {
 
   return (
     <>
-      {onboardingConnect && <Connect moveToOnboardingCode={moveToOnboardingCode} />}
+      {onboardingConnect && (
+        <Connect moveToOnboardingCode={moveToOnboardingCode} moveToOnboardingCustom={moveToOnboardingCustom} />
+      )}
       {onboardingCode && (
         <Code moveToOnboardingConnect={moveToOnboardingConnect} moveToOnboardingCustom={moveToOnboardingCustom} />
       )}

--- a/lubee/src/splash/index.tsx
+++ b/lubee/src/splash/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import { LogoGrayIc, SymbolIc } from "@assets/index";
+import { LogoGrayIc, SymbolIc } from "assets/index";
 import CompanyText from "@common/components/CompanyText";
 
 export default function index() {

--- a/lubee/src/upload/components/SelectLocationModal.tsx
+++ b/lubee/src/upload/components/SelectLocationModal.tsx
@@ -1,4 +1,4 @@
-import { SearchIc, XIc } from "@assets/index";
+import { SearchIc, XIc } from "assets/index";
 import styled from "styled-components";
 import { BtnWrapper } from "@styles/btnStyle";
 import { useDebounce } from "@common/utils/useDebounce";

--- a/lubee/src/upload/location/index.tsx
+++ b/lubee/src/upload/location/index.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
-import { BackIc } from "@assets/index";
-import { SearchIc } from "@assets/index";
+import { BackIc } from "assets/index";
+import { SearchIc } from "assets/index";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { BtnWrapper } from "@styles/btnStyle";

--- a/lubee/src/upload/pic/index.tsx
+++ b/lubee/src/upload/pic/index.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { BackIc, ShareBtnIc } from "@assets/index";
+import { BackIc, ShareBtnIc } from "assets/index";
 import FullPicContainer from "@common/components/FullPicContainer";
 import { useState } from "react";
 import SelectLocationModal from "upload/components/SelectLocationModal";

--- a/lubee/tsconfig.json
+++ b/lubee/tsconfig.json
@@ -26,7 +26,6 @@
     "paths": {
       "@api/*": ["api/*"],
       "@atom/*": ["atom/*"],
-      "@assets/*": ["assets/*"],
       "@components/*": ["components/*"],
       "@core/*": ["core/*"],
       "@hooks/*": ["hooks/*"],


### PR DESCRIPTION
## Related Issues

- close #81

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 변경 사항 in Detail

- [x] 이미 커플인 경우
  - lubeeCode값이 변경될 때마다 useEffect로 상태 업데이트해서 ALREADY_COUPLE인 경우 반영
  - lubeeCode가 ALREADY_COUPLE인 경우 토스트로 알림 띄운 후 custom 페이지로 이동
  - 첫 번째 useEffect: KAKAO_CODE가 존재하면 로그인 요청을 수행하고 성공 시 토큰을 설정. 로그인 요청이 성공하면 토큰을 설정하고, couplesInfoResponse가 아직 로딩 중일 수 있으므로 isLoading과 couplesInfoResponse의 상태를 별도로 처리
  - 두 번째 useEffect: couplesInfoResponse의 상태 변화에 따라 isLoading이 끝나고 couplesInfoResponse가 존재하면 라우팅실행. -> useGetCouplesInfo의 비동기 데이터를 기다리면서 couplesInfoResponse가 success인 경우와 아닌 경우에 따라 라우팅을 분기 처리
```
const [lubeeCode, setLubeeCode] = useState<any>(null);

  // useGetLubeeCode 훅을 사용한 상태 업데이트
  const fetchedLubeeCode = useGetLubeeCode();

  useEffect(() => {
    // lubeeCode 값이 변경될 때마다 상태 업데이트
    if (fetchedLubeeCode) {
      setLubeeCode(fetchedLubeeCode);
    }
  }, [fetchedLubeeCode]);

  useEffect(() => {
    if (lubeeCode?.response?.code === "ALREADY_COUPLE") {
      infoToast("이미 커플로 등록된 상태입니다.");
      setTimeout(() => {
        moveToOnboardingCustom();
      }, 2000);
    }
  }, [lubeeCode, moveToOnboardingCustom]);

  if (!lubeeCode) return <></>;

  const {
    response: { code },
  } = lubeeCode;
```
  - 로그인해서 useGetCoupleInfo로 이미 커플인 경우 커플 정보를 불러와서 성공일 시 home/today로 이동
  - useGetCouplesInfo에서 isLoading과 error도 받아와서 usePostLogin에서 의존성 배열에 추가
```
const usePostLogin = () => {
  const KAKAO_CODE = new URL(window.location.href).searchParams.get("code");
  const navigate = useNavigate();
  const { data: couplesInfoResponse, isLoading, error } = useGetCouplesInfo();

  useEffect(() => {
    if (KAKAO_CODE) {
      api
        .post(`api/users/kakao/simpleLogin?code=${KAKAO_CODE}`)
        .then((res) => {
          const data = res.data as loginResProps; // AxiosResponse의 data를 loginResProps로 단언
          setToken(data.response.accessToken);
          console.log("로그인 성공");
          console.log("로그인 데이터", data);
        })
        .catch((err) => {
          const errorData = err.response.data as loginErrorProps; // 에러 응답 데이터 단언
          if (errorData.success_or_error_code.status === 404) {
            setToken(errorData.response.accessToken);
            navigate("/onboarding");
          } else {
            navigate("/error");
            console.log(KAKAO_CODE);
          }
        });
    }
  }, [KAKAO_CODE, navigate]);

  useEffect(() => {
    if (!isLoading && couplesInfoResponse) {
      console.log("커플정보 얻기", couplesInfoResponse.success);
      if (couplesInfoResponse.success) {
        console.log(couplesInfoResponse);
        navigate("/home/today");
      } else {
        navigate("/onboarding");
      }
    } else if (!isLoading && error) {
      console.log("커플 정보 가져오기 실패", error);
      navigate("/error");
    }
  }, [isLoading, couplesInfoResponse, error, navigate]);
};

export default usePostLogin;
```
- [x] 온보딩 코드 복사 페이지에서 초대장 보내기에 실제 코드 담아서 보내기
- [x] 축하페이지 버튼 조건 추가
```js
  function handleOnboardingBtn() {
    if (couplesInfoResponse?.success) {
      // 둘다 온보딩 post를 날려서 커플정보를 얻을 수 있는 경우
      navigate("/home/today");
    } else {
      infoToast("연인이 커플정보를 입력하지 않았어요!");
    }
  }
```
- [x] 이미지 assets 안불러와지는 문제 해결
   - tsconfig.json /* Path and Alias */ 에서 src>assets는 @assets로 할 수 있게 처리했으나 경로를 읽는과정에서 에러발생
   - @assets -> assets로 변경

## 다음에 할 것

- [ ] 프로필 출력 API 확인 후 pr 머지
