### PR TITLE
comment_first, comment_second로 수정된 오늘의 데이트 코멘트 조회 API

### DIFF
--- a/lubee/src/home/api/getTodayDateComment.ts
+++ b/lubee/src/home/api/getTodayDateComment.ts
@@ -2,21 +2,16 @@ import api from "@common/api/api";
 import { Response } from "@common/types/Response";
 
 interface TodayDateCommentDataTypes {
-  content: string;
-  profile: string | null;
+  comment_first: string;
+  comment_second: string;
 }
 
 interface GetTodayDateCommentRequest {
   date: string;
 }
 
-interface GetTodayDateCommentResponse {
-  mine: TodayDateCommentDataTypes;
-  lover: TodayDateCommentDataTypes | null;
-}
-
 export async function getTodayDateComment({ date }: GetTodayDateCommentRequest) {
-  const { data } = await api.get<Response<GetTodayDateCommentResponse>>(`/api/datecomments/today?date=${date}`);
+  const { data } = await api.get<Response<TodayDateCommentDataTypes>>(`/api/datecomments/today?date=${date}`);
 
   return data;
 }

--- a/lubee/src/home/month/components/DateDetailModal.tsx
+++ b/lubee/src/home/month/components/DateDetailModal.tsx
@@ -44,12 +44,9 @@ const DateDetailModal = forwardRef<HTMLDivElement, DateDetailModalProps>((props,
   const isToday = false;
   const finalServerDate = isToday ? getServerDate() : serverDate; //오늘 홈에서 코멘트 조회 요청은 오늘날짜, 과거에서 코멘트 조회 요청은 선택한 날짜로
   const commentData = useGetTodayDateComment(finalServerDate);
-  if (!commentData) return <></>;
-  const { response } = commentData;
-  const { mine, lover } = response || {};
 
-  const myComment = mine?.content || "";
-  const partnerComment = lover?.content || "";
+  const myComment = commentData?.response?.comment_first || "";
+  const partnerComment = commentData?.response?.comment_second || "";
 
   return (
     <Background>

--- a/lubee/src/home/month/components/DateDetailModal.tsx
+++ b/lubee/src/home/month/components/DateDetailModal.tsx
@@ -40,13 +40,13 @@ const DateDetailModal = forwardRef<HTMLDivElement, DateDetailModalProps>((props,
   const myProfile = getProfileIconSrc("me", profile_first);
   const partnerProfile = getProfileIconSrc("partner", profile_second);
 
-  /*혜연이 부분*/
+  /*코멘트 부분*/
   const isToday = false;
   const finalServerDate = isToday ? getServerDate() : serverDate; //오늘 홈에서 코멘트 조회 요청은 오늘날짜, 과거에서 코멘트 조회 요청은 선택한 날짜로
   const commentData = useGetTodayDateComment(finalServerDate);
-
-  const myComment = commentData?.response?.comment_first || "";
-  const partnerComment = commentData?.response?.comment_second || "";
+  const { response } = commentData || {};
+  const myComment = response?.comment_first || "";
+  const partnerComment = response?.comment_second || "";
 
   return (
     <Background>

--- a/lubee/src/home/today/components/ContentContainer.tsx
+++ b/lubee/src/home/today/components/ContentContainer.tsx
@@ -35,12 +35,8 @@ export default function ContentContainer(props: ContentContainerProps) {
   const finalServerDate = isToday ? getServerDate() : date; //오늘 홈에서 코멘트 조회 요청은 오늘날짜, 과거에서 코멘트 조회 요청은 선택한 날짜로
   const commentData = useGetTodayDateComment(finalServerDate);
 
-  const { response: commentResponse } = commentData || {};
-  const mine = commentResponse?.mine;
-  const lover = commentResponse?.lover;
-
-  const myComment = mine?.content || "";
-  const partnerComment = lover?.content || "";
+  const myComment = commentData?.response?.comment_first || "";
+  const partnerComment = commentData?.response?.comment_second || "";
 
   // 데이터가 없을 경우 빈 화면을 반환
   if (!CoupleInfo || !commentData) return <></>;

--- a/lubee/src/home/today/components/ContentContainer.tsx
+++ b/lubee/src/home/today/components/ContentContainer.tsx
@@ -39,7 +39,7 @@ export default function ContentContainer(props: ContentContainerProps) {
   const partnerComment = response?.comment_second || "";
 
   // 데이터가 없을 경우 빈 화면을 반환
-  if (!CoupleInfo || !commentData) return <></>;
+  if (!CoupleInfo) return <></>;
 
   return (
     <Container>

--- a/lubee/src/home/today/components/ContentContainer.tsx
+++ b/lubee/src/home/today/components/ContentContainer.tsx
@@ -31,12 +31,12 @@ export default function ContentContainer(props: ContentContainerProps) {
   const data = useGetSpecificCalendar({ year: getTodayYear, month: getTodayMonth, day: getTodayDate });
   specificDto = data?.response.memoryBaseListDto;
 
-  /*혜연이 부분*/
+  /*코멘트 부분*/
   const finalServerDate = isToday ? getServerDate() : date; //오늘 홈에서 코멘트 조회 요청은 오늘날짜, 과거에서 코멘트 조회 요청은 선택한 날짜로
   const commentData = useGetTodayDateComment(finalServerDate);
-
-  const myComment = commentData?.response?.comment_first || "";
-  const partnerComment = commentData?.response?.comment_second || "";
+  const { response } = commentData || {};
+  const myComment = response?.comment_first || "";
+  const partnerComment = response?.comment_second || "";
 
   // 데이터가 없을 경우 빈 화면을 반환
   if (!CoupleInfo || !commentData) return <></>;

--- a/lubee/src/settings/hooks/useSetInterceptors.ts
+++ b/lubee/src/settings/hooks/useSetInterceptors.ts
@@ -8,7 +8,6 @@ const useSetInterceptors = () => {
   useLayoutEffect(() => {
     api.interceptors.request.use((config) => {
       const accessToken = getToken();
-      console.log(accessToken);
       if (accessToken) {
         config.headers["Authorization"] = `Bearer ${accessToken}`;
       }


### PR DESCRIPTION
## Related Issues

- close #89 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 오류 수정


## 변경 사항 in Detail

- [x] 오늘의 데이트 코멘트 api
  - 수정한 api에 따라 comment_first와 comment_second로 로그인한 유저는 comment_first를 출력
```
{
    "success": true,
    "response": {
        "comment_first": "ddddddddddddddddddddddddddddddddddd",
        "comment_second": ""
    },
    "success_or_error_code": {
        "status": 200,
        "message": "상대방은 데이트코멘트를 작성하지 않았습니다."
    }
}
```

## 다음에 할 것

- [ ] EmojiDetailModal에서 프로필 출력
