### PR TITLE
emoji post/update 경우의 수 수정, fullpic/date 페이지네이션으로 변경

### DIFF
--- a/lubee/src/@common/components/EmojiBar.tsx
+++ b/lubee/src/@common/components/EmojiBar.tsx
@@ -21,9 +21,7 @@ export default function EmojiBar(props: EmojiBarProps) {
   const [emoji, setEmoji] = useState<string>("");
 
   const { data: emojiData } = useGetOnePic(memory_id);
-  if (!emojiData) return <></>;
 
-  // get 상태 업데이트
   useEffect(() => {
     if (emojiData) {
       setUpdatedData(emojiData.response);
@@ -32,7 +30,7 @@ export default function EmojiBar(props: EmojiBarProps) {
 
   useEffect(() => {
     if (updatedData) {
-      setEmoji(updatedData.reaction_first || ""); // 타입 에러
+      setEmoji(updatedData.reaction_first || "");
     }
   }, [updatedData]);
 
@@ -58,6 +56,11 @@ export default function EmojiBar(props: EmojiBarProps) {
   }
   function handleSmile() {
     toggleEmoji("smile");
+  }
+
+  // 데이터 Unavailable시
+  if (!emojiData) {
+    return <div>Loading...</div>;
   }
 
   return (

--- a/lubee/src/@common/components/EmojiBar.tsx
+++ b/lubee/src/@common/components/EmojiBar.tsx
@@ -7,21 +7,36 @@ import {
   YellowThumbBigIcon,
 } from "@common/components/BigEmojiIcons";
 import styled from "styled-components";
+import { useGetOnePic } from "fullpic/hooks/useGetOnePic";
+import { MemoryBaseDtoDataTypes } from "fullpic/api/getOnePic";
 
 interface EmojiBarProps {
   setSelectedEmojiText: (emoji: string) => void;
-  selectedEmojiText: string;
+  memory_id: number;
 }
 
 export default function EmojiBar(props: EmojiBarProps) {
-  const { setSelectedEmojiText, selectedEmojiText } = props;
-  const [emoji, setEmoji] = useState(selectedEmojiText);
-  // const [emoji, setEmoji] = useState<string>(() => {
-  //   return localStorage.getItem("emoji") || "";
-  // });
+  const { setSelectedEmojiText, memory_id } = props;
+  const [updatedData, setUpdatedData] = useState<MemoryBaseDtoDataTypes | null>(null);
+  const [emoji, setEmoji] = useState<string>("");
+
+  const { data: emojiData } = useGetOnePic(memory_id);
+  if (!emojiData) return <></>;
+
+  // get 상태 업데이트
+  useEffect(() => {
+    if (emojiData) {
+      setUpdatedData(emojiData.response);
+    }
+  }, [emojiData]);
 
   useEffect(() => {
-    // localStorage.setItem("emoji", emoji);
+    if (updatedData) {
+      setEmoji(updatedData.reaction_first || ""); // 타입 에러
+    }
+  }, [updatedData]);
+
+  useEffect(() => {
     setSelectedEmojiText(emoji);
   }, [emoji, setSelectedEmojiText]);
 

--- a/lubee/src/fullpic/components/EmojiDetailModal.tsx
+++ b/lubee/src/fullpic/components/EmojiDetailModal.tsx
@@ -3,21 +3,26 @@ import styled from "styled-components";
 import { forwardRef } from "react";
 import getEmojiSrc from "@common/utils/getEmojiSrc";
 import getProfileIconSrc from "@common/utils/getProfileIconSrc";
+import { useGetOnePic } from "fullpic/hooks/useGetOnePic";
 
 interface EmojiDetailModalProps {
   selectedEmojiText: string;
+  memory_id: number;
 }
 
 const EmojiDetailModal = forwardRef<HTMLDivElement, EmojiDetailModalProps>((props, ref) => {
-  const { selectedEmojiText } = props;
+  const { selectedEmojiText, memory_id } = props;
 
   /* 서버한테 어떤 프로필을 선택했는지 받아오면 됨*/
   const myProfile = getProfileIconSrc("me", "profile1");
   const partnerProfile = getProfileIconSrc("partner", "profile2");
 
   /* 서버한테 어떤 공감을 선택했는지 받아오면 됨*/
-  const myEmoji = getEmojiSrc("me", selectedEmojiText) || undefined;
-  const partnerEmoji = getEmojiSrc("partner", selectedEmojiText) || undefined;
+  const { data: emojiData } = useGetOnePic(memory_id);
+  if (!emojiData) return <></>;
+
+  const myEmoji = getEmojiSrc("me", selectedEmojiText) || undefined; //내 이모지는 바뀔 수 있으니까 selected로
+  const partnerEmoji = getEmojiSrc("partner", emojiData.response.reaction_second) || undefined;
 
   return (
     <Background>

--- a/lubee/src/fullpic/date/components/DateContainer.tsx
+++ b/lubee/src/fullpic/date/components/DateContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import EmojiBar from "@common/components/EmojiBar";
 import FullPicContainer from "@common/components/FullPicContainer";
@@ -18,9 +18,31 @@ interface DateContainerProps {
 
 export default function DateContainer(props: DateContainerProps) {
   const { setOpenEmojiDetail, selectedEmojiText, setSelectedEmojiText, specificDto, memory_id, setMemoryId } = props;
+  /*페이지 네이션*/
   const [currentPage, setCurrentPage] = useState(0);
-  const itemsPerPage = 1; // Change this to the number of items you want to show per page
+  const itemsPerPage = 1;
   const totalPages = Math.ceil(specificDto.length / itemsPerPage);
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  // memory_id와 일치하는 페이지
+  useEffect(() => {
+    const initialPage = specificDto.findIndex((item) => item.memory_id === memory_id);
+    if (initialPage !== -1) {
+      setCurrentPage(Math.floor(initialPage / itemsPerPage));
+    }
+  }, [memory_id, specificDto, itemsPerPage]);
+
+  // 클릭한 memory_id가 먼저 보이게 하는 ref
+  useEffect(() => {
+    const initialPage = specificDto.findIndex((item) => item.memory_id === memory_id);
+    if (initialPage !== -1 && itemRefs.current[initialPage % itemsPerPage]) {
+      itemRefs.current[initialPage % itemsPerPage]?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+        inline: "center",
+      });
+    }
+  }, [currentPage, memory_id, specificDto, itemsPerPage]);
 
   const handlePrevPage = () => {
     if (currentPage > 0) {
@@ -66,7 +88,7 @@ export default function DateContainer(props: DateContainerProps) {
         const partnerEmoji = reaction_second ? getEmojiSrc("partner", reaction_second) : undefined;
 
         return (
-          <ContentsBox key={picMemoryId}>
+          <ContentsBox key={picMemoryId} ref={(el) => (itemRefs.current[index] = el)}>
             <Time>{upload_time}</Time>
             <Profile>
               <ProfileIcon as={profile} />
@@ -177,13 +199,14 @@ const Pagination = styled.div`
 `;
 
 const PageButton = styled.button`
-  padding: 0.5rem 1rem;
-  border: none;
-  color: white;
+  padding: 0.2rem 0.5rem;
+  border-radius: 5px;
+  background-color: ${({ theme }) => theme.colors.yellow};
+  color: ${({ theme }) => theme.colors.white};
   cursor: pointer;
 
   &:disabled {
-    background: ${({ theme }) => theme.colors.gray_500};
+    background-color: ${({ theme }) => theme.colors.gray_50};
     cursor: not-allowed;
   }
 `;

--- a/lubee/src/fullpic/date/components/DateContainer.tsx
+++ b/lubee/src/fullpic/date/components/DateContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import EmojiBar from "@common/components/EmojiBar";
 import FullPicContainer from "@common/components/FullPicContainer";
@@ -18,59 +18,31 @@ interface DateContainerProps {
 
 export default function DateContainer(props: DateContainerProps) {
   const { setOpenEmojiDetail, selectedEmojiText, setSelectedEmojiText, specificDto, memory_id, setMemoryId } = props;
-  const picRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [currentPage, setCurrentPage] = useState(0);
+  const itemsPerPage = 1; // Change this to the number of items you want to show per page
+  const totalPages = Math.ceil(specificDto.length / itemsPerPage);
 
-  // 스크롤할때마다 memoryId를 반영할 수 있게
-  const observer = useRef<IntersectionObserver | null>(null);
-  const handleIntersection = useCallback(
-    (entries: IntersectionObserverEntry[]) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          const picMemoryId = entry.target.getAttribute("data-memory-id");
-          if (picMemoryId) {
-            setMemoryId(Number(picMemoryId));
-          }
-        }
-      });
-    },
-    [setMemoryId],
-  );
-  useEffect(() => {
-    observer.current = new IntersectionObserver(handleIntersection, {
-      root: null,
-      rootMargin: "0px",
-      threshold: 0.5,
-    });
-
-    const currentObserver = observer.current;
-    picRefs.current.forEach((pic) => {
-      if (pic) currentObserver.observe(pic);
-    });
-
-    return () => {
-      picRefs.current.forEach((pic) => {
-        if (pic) currentObserver.unobserve(pic);
-      });
-    };
-  }, [specificDto, handleIntersection]);
-
-  // 클릭한 memory_id와 일치하는 pic가는 ref
-  useEffect(() => {
-    const index = specificDto.findIndex((item) => item.memory_id === memory_id);
-
-    // 매칭 pic으로 스크롤
-    if (index !== -1 && picRefs.current[index]) {
-      picRefs.current[index]?.scrollIntoView({
-        behavior: "smooth",
-        block: "center",
-        inline: "center",
-      });
+  const handlePrevPage = () => {
+    if (currentPage > 0) {
+      const newPage = currentPage - 1;
+      setCurrentPage(newPage);
+      setMemoryId(specificDto[newPage * itemsPerPage].memory_id);
     }
-  }, [specificDto, memory_id]);
+  };
+
+  const handleNextPage = () => {
+    if (currentPage < totalPages - 1) {
+      const newPage = currentPage + 1;
+      setCurrentPage(newPage);
+      setMemoryId(specificDto[newPage * itemsPerPage].memory_id);
+    }
+  };
+
+  const currentItems = specificDto.slice(currentPage * itemsPerPage, (currentPage + 1) * itemsPerPage);
 
   return (
     <Wrapper>
-      {specificDto.map((data, index) => {
+      {currentItems.map((data, index) => {
         const {
           memory_id: picMemoryId,
           user_id,
@@ -88,12 +60,13 @@ export default function DateContainer(props: DateContainerProps) {
           if (reaction_first) {
             setSelectedEmojiText(reaction_first);
           }
-        }, [reaction_first]);
+        }, [reaction_first, setSelectedEmojiText]);
+
         const myEmoji = getEmojiSrc("me", selectedEmojiText) || undefined;
         const partnerEmoji = reaction_second ? getEmojiSrc("partner", reaction_second) : undefined;
 
         return (
-          <ContentsBox key={picMemoryId} ref={(el) => (picRefs.current[index] = el)}>
+          <ContentsBox key={picMemoryId}>
             <Time>{upload_time}</Time>
             <Profile>
               <ProfileIcon as={profile} />
@@ -120,26 +93,33 @@ export default function DateContainer(props: DateContainerProps) {
           </ContentsBox>
         );
       })}
+      <Pagination>
+        <PageButton onClick={handlePrevPage} disabled={currentPage === 0}>
+          {"<"}
+        </PageButton>
+        <PageIndicator>
+          {currentPage + 1} / {totalPages}
+        </PageIndicator>
+        <PageButton onClick={handleNextPage} disabled={currentPage === totalPages - 1}>
+          {">"}
+        </PageButton>
+      </Pagination>
     </Wrapper>
   );
 }
 
 const Wrapper = styled.section`
   display: flex;
-  overflow-x: auto;
-  scroll-behavior: smooth;
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
-
-  &::-webkit-scrollbar {
-    display: none; /* Chrome, Safari, Opera */
-  }
+  flex-direction: column;
+  align-items: center;
+  overflow-x: hidden;
 `;
 
 const ContentsBox = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-bottom: 2rem;
 `;
 
 const Time = styled.p`
@@ -187,4 +167,30 @@ const Footer = styled.div`
 const EmojiIcon = styled.svg`
   width: 2.4rem;
   height: 2.4rem;
+`;
+
+const Pagination = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 1rem;
+`;
+
+const PageButton = styled.button`
+  padding: 0.5rem 1rem;
+  border: none;
+  color: white;
+  cursor: pointer;
+
+  &:disabled {
+    background: ${({ theme }) => theme.colors.gray_500};
+    cursor: not-allowed;
+  }
+`;
+
+const PageIndicator = styled.span`
+  margin: 0 1rem;
+  ${({ theme }) => theme.fonts.Body_3}
+
+  color: ${({ theme }) => theme.colors.gray_900};
 `;

--- a/lubee/src/fullpic/date/components/DateContainer.tsx
+++ b/lubee/src/fullpic/date/components/DateContainer.tsx
@@ -115,7 +115,7 @@ export default function DateContainer(props: DateContainerProps) {
               </EmojiTagContainer>
             )}
             <Footer>
-              <EmojiBar setSelectedEmojiText={setSelectedEmojiText} selectedEmojiText={selectedEmojiText} />
+              <EmojiBar setSelectedEmojiText={setSelectedEmojiText} memory_id={picMemoryId} />
             </Footer>
           </ContentsBox>
         );

--- a/lubee/src/fullpic/date/index.tsx
+++ b/lubee/src/fullpic/date/index.tsx
@@ -59,7 +59,9 @@ export default function index() {
         setMemoryId={setMemoryId}
       />
       {openDeletePicModal && <DeletePicModal handleTrashBtn={handleTrashBtn} memory_id={memoryId} />}
-      {openEmojiDetail && <EmojiDetailModal ref={modalRef} selectedEmojiText={selectedEmojiText} />}
+      {openEmojiDetail && (
+        <EmojiDetailModal ref={modalRef} selectedEmojiText={selectedEmojiText} memory_id={memoryId} />
+      )}
     </Wrapper>
   );
 }

--- a/lubee/src/fullpic/one/index.tsx
+++ b/lubee/src/fullpic/one/index.tsx
@@ -93,7 +93,7 @@ export default function index() {
         </EmojiTagContainer>
       )}
       <Footer>
-        <EmojiBar setSelectedEmojiText={setSelectedEmojiText} selectedEmojiText={selectedEmojiText} />
+        <EmojiBar setSelectedEmojiText={setSelectedEmojiText} memory_id={memory_id} />
       </Footer>
       {openDeletePicModal && <DeletePicModal handleTrashBtn={handleTrashBtn} memory_id={memory_id} />}
       {openEmojiDetail && <EmojiDetailModal ref={modalRef} selectedEmojiText={selectedEmojiText} />}

--- a/lubee/src/fullpic/one/index.tsx
+++ b/lubee/src/fullpic/one/index.tsx
@@ -96,7 +96,9 @@ export default function index() {
         <EmojiBar setSelectedEmojiText={setSelectedEmojiText} memory_id={memory_id} />
       </Footer>
       {openDeletePicModal && <DeletePicModal handleTrashBtn={handleTrashBtn} memory_id={memory_id} />}
-      {openEmojiDetail && <EmojiDetailModal ref={modalRef} selectedEmojiText={selectedEmojiText} />}
+      {openEmojiDetail && (
+        <EmojiDetailModal ref={modalRef} selectedEmojiText={selectedEmojiText} memory_id={memory_id} />
+      )}
     </Wrapper>
   );
 }


### PR DESCRIPTION
## Related Issues

- close #94

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 오류 수정
- [x] CSS 등 스타일 변경

## 변경 사항 in Detail

- [x] 리액션 update, post 문제를 해결한 방법
      
      - 경우 1) 특정 사진이 리액션을 post를 할 경우 localstorage에 그 사진의 memory_id를 push  
      - 경우 2) 그 사진은 localstorage에 자신의 번호가 있기 때문에 다음부터는 무조건 update
      ‼️ 로컬스토리지 방법을 떠오르기까지 너어무 오랜 시간이 걸렸다 에휴..

- [x] ‼️ 트러블슈팅 이모지 경우의 수 관련
1. 헤더의 뒤로가기버튼을 눌렀을때 navigate도 하기 때문에 state가 제대로 업데이트가 안되고 
2. localstorage에 memory_id가 push가 안되는 일이 발생했다 
```js
  // 로컬 스토리지에서 배열 가져오기
  const [numbersArray, setNumbersArray] = useState<number[]>(JSON.parse(localStorage.getItem("numbersArray") || "[]"));

```
3. Json에서 얻은 배열은 useState로 관리하고 새로운 memory_id를 push하는 배열은 따로 업데이트 배열에다가 저장해서 useEffect로 해결
```js
  useEffect(() => {
    // 배열을 다시 로컬 스토리지에 저장
    localStorage.setItem("numbersArray", JSON.stringify(numbersArray));
    console.log("업데이트 배열:", numbersArray);
  }, [numbersArray]);
```

```js
// post 성공시 array에 push함으로써 배열에 특정 숫자가 있는지 확인하는 함수로 post를 2번 안하게 
            onSuccess: () => {
              // 배열에 숫자 추가
              const updatedArray = [...numbersArray, memory_id];
              setNumbersArray(updatedArray);
              // 로컬 스토리지에 업데이트된 배열 저장
              localStorage.setItem("numbersArray", JSON.stringify(updatedArray));
              // 페이지 이동
              if (prevPage === "today") {
                navigate("/home/today");
              } else {
                navigate("/home/month");
              }
            },
```

⭐️ localstorage는 string이 아니라 **배열을 저장할 때는 파싱**하는 과정이 필요`localStorage.setItem("numbersArray", JSON.stringify(numbersArray));`

- [x] ‼️ 트러블슈팅 슬라이딩 시 리액션 변경 관련
   이것도 너무너무 어려워서 결국 해결하지 못하고 기존 이미지 슬라이드 -> 페이지네이션으로 디자인을 변경할 수 밖에 없었어 ㅜㅜ 
   일단, 이미지를 옆으로 넘기는 것을 버튼이 아닌 그냥 슬라이딩으로 구현하면 이모지 태그와 이모지 디테일 모달이 화면에 이미지가 변경되는 시점에 맞게 그 이미지의 이모지로 변경이 되어야하는데 이모지 태그가 position이 absolute로 박혀있기 때문에 반영이 되지 않았어
   그리고 memory_id가 확실해야 거기서도 리액션 즉 이모지를 수정, post를 할 수 있기 때문에 어쩔 수 없이 페이지네이션으로 확실히 이 페이지가 그 memory_id임을 보여줄 수 밖에 없었다는 ㅜㅜ
   따라서 변경된 디자인은 아래 하단에 버튼이 생겼어 (영상이 지금 녹화가 안돼서ㅜ 영상을 보여주고 싶은데 ㅠ)
<img width="403" alt="스크린샷 2024-07-29 오전 1 33 51" src="https://github.com/user-attachments/assets/c6e07147-b7b1-40ed-9248-5eba338689bb">

- [x] 처음 큰 사진을 띄웠을 때 그 사진위에 올라와있는 태그와 리액션을 선택할 수 있는 그 바가 일치할 수 있도록.. 그것도 바꿔두었어! 그리고 EmojiDetailModal에서도 마찬가지로..! 

## 다음에 할 것

- [x] #88 
