### PR TITLE
기록을 추가했을 경우에만 꿀 개수에 따라 축하페이지로 이동하기

### DIFF
--- a/lubee/src/home/hooks/useGetTodayHoney.ts
+++ b/lubee/src/home/hooks/useGetTodayHoney.ts
@@ -2,11 +2,13 @@ import { useQuery } from "react-query";
 import { getTodayHoney } from "../api/getTodayHoney";
 
 export function useGetTodayHoney(date: string) {
-  const { data } = useQuery(["getTodayHoney", date], () => getTodayHoney({ date }), {
+  const queryResult = useQuery(["getTodayHoney", date], () => getTodayHoney({ date }), {
     onError: (error) => {
       console.log("에러 발생", error);
     },
   });
 
-  return data;
+  // queryResult에는 data, isLoading, isFetching 등이 모두 포함됨.
+  // 꿀 개수 조회로 축하 페이지 이동 위한 isLoading, isFetching
+  return queryResult;
 }

--- a/lubee/src/home/today/index.tsx
+++ b/lubee/src/home/today/index.tsx
@@ -17,7 +17,7 @@ export default function index() {
   const [openToggle, setOpenToggle] = useState<boolean>(false);
   const [showCalendar, setShowCalendar] = useState<boolean>(false);
   const [isPlusClicked, setIsPlusClicked] = useState<boolean>(false);
-  const totalHoney = useGetTodayHoney(getServerDate());
+  const { data: totalHoney } = useGetTodayHoney(getServerDate());
   const loveDay = useGetLoveDay();
 
   if (!totalHoney || !loveDay || !loveDay?.response) return <></>;

--- a/lubee/src/loading/index.tsx
+++ b/lubee/src/loading/index.tsx
@@ -1,15 +1,30 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-
 import CompanyText from "@common/components/CompanyText";
 import { SymbolIc } from "assets";
+/* 오늘의 꿀 조회로 1개, 5개일 때 congrats로 navigate*/
+import { useGetTodayHoney } from "home/hooks/useGetTodayHoney";
+import { getServerDate } from "@common/utils/dateFormat";
 
 export default function index() {
+  const totalHoney = useGetTodayHoney(getServerDate());
+  if (!totalHoney) return <></>;
+
+  const { response } = totalHoney;
+
   const navigate = useNavigate();
   useEffect(() => {
     localStorage.getItem("currentPage");
   }, []);
+
+  useEffect(() => {
+    if (response === 1) {
+      navigate("/congrats/first");
+    } else if (response === 5) {
+      navigate("/congrats/fifth");
+    }
+  }, [response, navigate]);
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/lubee/src/loading/index.tsx
+++ b/lubee/src/loading/index.tsx
@@ -22,13 +22,8 @@ export default function index() {
           const { response } = updatedHoney;
           console.log("Fetched honey count:", response);
 
-          if (previousHoney === null) {
-            setPreviousHoney(response);
-            return;
-          }
-
           // 꿀 개수가 이전보다 증가한 경우에만 축하 페이지로 이동
-          if (response > previousHoney) {
+          if (previousHoney !== null && response > previousHoney) {
             if (response === 1) {
               navigate("/congrats/first");
             } else if (response === 5) {
@@ -64,7 +59,7 @@ export default function index() {
       }
     };
 
-    const timer = setTimeout(fetchHoney, 3000); // 3초 후에 꿀 개수를 불러와서 화면 이동
+    const timer = setTimeout(fetchHoney, 2000); // 2초 후에 꿀 개수를 불러와서 화면 이동. 2초 기다린 후 꿀 개수 불러오는 데 추가로 더 걸려서 수정...
 
     return () => clearTimeout(timer);
   }, [navigate, refetchHoney, previousHoney]);

--- a/lubee/src/loading/index.tsx
+++ b/lubee/src/loading/index.tsx
@@ -23,8 +23,6 @@ export default function index() {
         const { data: updatedHoney } = await refetchHoney();
         if (updatedHoney !== undefined) {
           const { response } = updatedHoney;
-          console.log("Fetched honey count:", response);
-          console.log("Previous honey count:", previousHoney);
 
           if (previousHoney === null) {
             setPreviousHoney(response);
@@ -34,7 +32,6 @@ export default function index() {
 
           if (response > previousHoney) {
             // 꿀 개수가 이전보다 증가한 경우
-            console.log("Honey count increased:", previousHoney, "->", response);
             if (response === 1) {
               navigate("/congrats/first");
             } else if (response === 5) {

--- a/lubee/src/loading/index.tsx
+++ b/lubee/src/loading/index.tsx
@@ -8,36 +8,41 @@ import { useGetTodayHoney } from "home/hooks/useGetTodayHoney";
 import { getServerDate } from "@common/utils/dateFormat";
 
 export default function index() {
-  const totalHoney = useGetTodayHoney(getServerDate());
-  if (!totalHoney) return <></>;
-
-  const { response } = totalHoney;
-
   const navigate = useNavigate();
+  const { data: totalHoney, isLoading, isFetching } = useGetTodayHoney(getServerDate());
+
   useEffect(() => {
     localStorage.getItem("currentPage");
   }, []);
 
   useEffect(() => {
-    if (response === 1) {
-      navigate("/congrats/first");
-    } else if (response === 5) {
-      navigate("/congrats/fifth");
+    // 로딩 상태일 때 로딩 화면 표시
+    if (isLoading || isFetching) {
+      return;
     }
-  }, [response, navigate]);
+  }, [isLoading, isFetching]);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      const prevPage = localStorage.getItem("currentPage");
-      if (prevPage === "today") {
-        navigate("/home/today");
+    if (!isLoading && !isFetching && totalHoney !== undefined) {
+      const { response } = totalHoney;
+      if (response === 1) {
+        navigate("/congrats/first");
+      } else if (response === 5) {
+        navigate("/congrats/fifth");
       } else {
-        navigate("/home/month");
-      }
-    }, 3000); // 3초 후에 로그인 페이지로 이동
+        const timer = setTimeout(() => {
+          const prevPage = localStorage.getItem("currentPage");
+          if (prevPage === "today") {
+            navigate("/home/today");
+          } else {
+            navigate("/home/month");
+          }
+        }, 3000); // 3초 후에 홈 페이지로 이동
 
-    return () => clearTimeout(timer); // 컴포넌트 언마운트 시 타이머 정리
-  }, [navigate]);
+        return () => clearTimeout(timer); // 컴포넌트 언마운트 시 타이머 정리
+      }
+    }
+  }, [totalHoney, isLoading, isFetching, navigate]);
 
   return (
     <Wrapper>

--- a/lubee/src/loading/index.tsx
+++ b/lubee/src/loading/index.tsx
@@ -6,16 +6,16 @@ import { SymbolIc } from "assets";
 /* 오늘의 꿀 조회로 1개, 5개일 때 congrats로 navigate*/
 import { useGetTodayHoney } from "home/hooks/useGetTodayHoney";
 import { getServerDate } from "@common/utils/dateFormat";
-import { usePostUploadPic } from "upload/hooks/usePostUploadPic";
 
 export default function index() {
   const navigate = useNavigate();
-  const { data: totalHoney, refetch: refetchHoney } = useGetTodayHoney(getServerDate());
+  const { refetch: refetchHoney } = useGetTodayHoney(getServerDate()); // refetch: refetchHoney: 데이터를 다시 가져오는 함수로, useEffect 훅 내에서 사용
 
   useEffect(() => {
     const timer = setTimeout(async () => {
       try {
         // 꿀 개수를 불러옴
+        // refetchHoney 함수는 비동기 함수로, 데이터를 다시 가져옴
         const { data: updatedHoney } = await refetchHoney();
         if (updatedHoney !== undefined) {
           const { response } = updatedHoney;

--- a/lubee/src/loading/index.tsx
+++ b/lubee/src/loading/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import CompanyText from "@common/components/CompanyText";
@@ -10,21 +10,37 @@ import { getServerDate } from "@common/utils/dateFormat";
 export default function index() {
   const navigate = useNavigate();
   const { refetch: refetchHoney } = useGetTodayHoney(getServerDate()); // refetch: refetchHoney: 데이터를 다시 가져오는 함수로, useEffect 훅 내에서 사용
+  const [previousHoney, setPreviousHoney] = useState<number | null>(null); // 이전 꿀 개수를 저장
 
   useEffect(() => {
-    const timer = setTimeout(async () => {
+    const fetchHoney = async () => {
+      // 꿀 개수를 불러옴
+      // refetchHoney 함수는 비동기 함수로, 데이터를 다시 가져옴
       try {
-        // 꿀 개수를 불러옴
-        // refetchHoney 함수는 비동기 함수로, 데이터를 다시 가져옴
         const { data: updatedHoney } = await refetchHoney();
         if (updatedHoney !== undefined) {
           const { response } = updatedHoney;
+          console.log("Fetched honey count:", response);
 
-          // 꿀 개수에 따라 다른 화면으로 이동
-          if (response === 1) {
-            navigate("/congrats/first");
-          } else if (response === 5) {
-            navigate("/congrats/fifth");
+          if (previousHoney === null) {
+            setPreviousHoney(response);
+            return;
+          }
+
+          // 꿀 개수가 이전보다 증가한 경우에만 축하 페이지로 이동
+          if (response > previousHoney) {
+            if (response === 1) {
+              navigate("/congrats/first");
+            } else if (response === 5) {
+              navigate("/congrats/fifth");
+            } else {
+              const prevPage = localStorage.getItem("currentPage");
+              if (prevPage === "today") {
+                navigate("/home/today");
+              } else {
+                navigate("/home/month");
+              }
+            }
           } else {
             const prevPage = localStorage.getItem("currentPage");
             if (prevPage === "today") {
@@ -33,10 +49,12 @@ export default function index() {
               navigate("/home/month");
             }
           }
+          // 이전 꿀 개수 업데이트
+          setPreviousHoney(response);
         }
       } catch (error) {
-        console.error("꿀 개수를 불러오는 중 오류 발생:", error);
         // 오류가 발생한 경우 기본 페이지로 이동
+        console.error("Error fetching honey count:", error);
         const prevPage = localStorage.getItem("currentPage");
         if (prevPage === "today") {
           navigate("/home/today");
@@ -44,10 +62,12 @@ export default function index() {
           navigate("/home/month");
         }
       }
-    }, 3000); // 3초 후에 꿀 개수를 불러와서 화면 이동
+    };
 
-    return () => clearTimeout(timer); // 컴포넌트 언마운트 시 타이머 정리
-  }, [navigate, refetchHoney]);
+    const timer = setTimeout(fetchHoney, 3000); // 3초 후에 꿀 개수를 불러와서 화면 이동
+
+    return () => clearTimeout(timer);
+  }, [navigate, refetchHoney, previousHoney]);
 
   // 무조건 기본으로 로딩 화면을 표시
   return (

--- a/lubee/src/loading/index.tsx
+++ b/lubee/src/loading/index.tsx
@@ -10,7 +10,10 @@ import { getServerDate } from "@common/utils/dateFormat";
 export default function index() {
   const navigate = useNavigate();
   const { refetch: refetchHoney } = useGetTodayHoney(getServerDate()); // refetch: refetchHoney: 데이터를 다시 가져오는 함수로, useEffect 훅 내에서 사용
-  const [previousHoney, setPreviousHoney] = useState<number | null>(null); // 이전 꿀 개수를 저장
+  const [previousHoney, setPreviousHoney] = useState<number | null>(() => {
+    const savedHoney = localStorage.getItem("previousHoney");
+    return savedHoney !== null ? JSON.parse(savedHoney) : null;
+  });
 
   useEffect(() => {
     const fetchHoney = async () => {
@@ -21,9 +24,17 @@ export default function index() {
         if (updatedHoney !== undefined) {
           const { response } = updatedHoney;
           console.log("Fetched honey count:", response);
+          console.log("Previous honey count:", previousHoney);
 
-          // 꿀 개수가 이전보다 증가한 경우에만 축하 페이지로 이동
-          if (previousHoney !== null && response > previousHoney) {
+          if (previousHoney === null) {
+            setPreviousHoney(response);
+            localStorage.setItem("previousHoney", JSON.stringify(response));
+            return;
+          }
+
+          if (response > previousHoney) {
+            // 꿀 개수가 이전보다 증가한 경우
+            console.log("Honey count increased:", previousHoney, "->", response);
             if (response === 1) {
               navigate("/congrats/first");
             } else if (response === 5) {
@@ -46,6 +57,7 @@ export default function index() {
           }
           // 이전 꿀 개수 업데이트
           setPreviousHoney(response);
+          localStorage.setItem("previousHoney", JSON.stringify(response));
         }
       } catch (error) {
         // 오류가 발생한 경우 기본 페이지로 이동

--- a/lubee/src/upload/hooks/usePostUploadPic.ts
+++ b/lubee/src/upload/hooks/usePostUploadPic.ts
@@ -3,7 +3,7 @@ import { postUploadPic, PostUploadPicDataTypes } from "upload/api/postUploadPic"
 
 export function usePostUploadPic() {
   return useMutation((data: PostUploadPicDataTypes) => postUploadPic(data), {
-    onSuccess: () => {
+    onSuccess: async () => {
       console.log("업로드 성공");
     },
     onError: (error) => {

--- a/lubee/src/upload/hooks/usePostUploadPic.ts
+++ b/lubee/src/upload/hooks/usePostUploadPic.ts
@@ -3,7 +3,7 @@ import { postUploadPic, PostUploadPicDataTypes } from "upload/api/postUploadPic"
 
 export function usePostUploadPic() {
   return useMutation((data: PostUploadPicDataTypes) => postUploadPic(data), {
-    onSuccess: async () => {
+    onSuccess: () => {
       console.log("업로드 성공");
     },
     onError: (error) => {


### PR DESCRIPTION
## Related Issues

- close #87 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 변경 사항 in Detail

- [x] 꿀 개수에 따라 축하페이지 이동
  - 기록 업로드/삭제 시 로딩페이지를 무조건 띄우기
  - 로딩페이지 띄울 동안 기록 업로드가 성공..!
  - 기록 업로드가 성공한 후 꿀 개수가 바뀌기 때문에 로딩페이지 2초 후에 꿀 개수 불러오기
  - 꿀 2개에서 하나 삭제해서 꿀 개수가 1개된 경우는 축하페이지로 이동하면 안되니까 꿀 개수를 불러와서 이전 꿀 개수보다 증가한 경우에만 1개 5개일 때 축하페이지로 이동하기
  - 처음에는 로딩페이지 3초로 해봤는데 로딩페이지 3초가 끝난 후에 꿀 개수 불러와서 축하페이지 이동하는 데 시간이 추가로 걸리는 것 같아서 2초로 바꿨어!


https://github.com/user-attachments/assets/dc31c988-08e9-45cf-a26f-1e105cfdd994


## 다음에 할 것

- [ ] EmojiDetailModal에서 프로필 출력
- [ ] 홈_오늘에서 blankBtn 클릭으로 기록 업로드
- [ ] 오늘 기록에서 기록 업로드
