### PR TITLE
fullpic페이지, EmojiDetailModal, MonthPicBox, TodayPicBox에서 작성자 프로필 출력

### DIFF
--- a/lubee/src/@common/utils/getHoverProfileIconSrc.ts
+++ b/lubee/src/@common/utils/getHoverProfileIconSrc.ts
@@ -1,12 +1,13 @@
 import { profileIconsData } from "@common/core/profileIconsData";
-import blankImg from "assets/image/blankImg.png";
+import { XIc } from "assets";
+
 const getHoverProfileIconSrc = (account: string, emoji: string) => {
   const accountData = profileIconsData.find((data) => data.account === account);
   if (accountData) {
     const iconData = accountData.profileIcon.find((icon) => icon.emoji === emoji);
-    return iconData ? iconData.hoverIconSrc : blankImg;
+    return iconData ? iconData.hoverIconSrc : XIc;
   }
-  return blankImg;
+  return XIc;
 };
 
 export default getHoverProfileIconSrc;

--- a/lubee/src/fullpic/components/EmojiDetailModal.tsx
+++ b/lubee/src/fullpic/components/EmojiDetailModal.tsx
@@ -2,7 +2,7 @@ import { ShortBorderIc } from "assets/index";
 import styled from "styled-components";
 import { forwardRef } from "react";
 import getEmojiSrc from "@common/utils/getEmojiSrc";
-import getProfileIconSrc from "@common/utils/getProfileIconSrc";
+import getHoverProfileIconSrc from "@common/utils/getHoverProfileIconSrc";
 import { useGetOnePic } from "fullpic/hooks/useGetOnePic";
 
 interface EmojiDetailModalProps {
@@ -13,16 +13,19 @@ interface EmojiDetailModalProps {
 const EmojiDetailModal = forwardRef<HTMLDivElement, EmojiDetailModalProps>((props, ref) => {
   const { selectedEmojiText, memory_id } = props;
 
-  /* 서버한테 어떤 프로필을 선택했는지 받아오면 됨*/
-  const myProfile = getProfileIconSrc("me", "profile1");
-  const partnerProfile = getProfileIconSrc("partner", "profile2");
-
   /* 서버한테 어떤 공감을 선택했는지 받아오면 됨*/
   const { data: emojiData } = useGetOnePic(memory_id);
   if (!emojiData) return <></>;
 
   const myEmoji = getEmojiSrc("me", selectedEmojiText) || undefined; //내 이모지는 바뀔 수 있으니까 selected로
   const partnerEmoji = getEmojiSrc("partner", emojiData.response.reaction_second) || undefined;
+
+  const writerProfileFirst = emojiData.response.writer_profile_first;
+  const writerProfileSecond = emojiData.response.writer_profile_second;
+
+  const isFirstWriter = writerProfileFirst !== null;
+  const myProfile = getHoverProfileIconSrc("me", isFirstWriter ? writerProfileFirst : writerProfileSecond);
+  const partnerProfile = getHoverProfileIconSrc("partner", isFirstWriter ? writerProfileSecond : writerProfileFirst);
 
   return (
     <Background>

--- a/lubee/src/fullpic/components/EmojiDetailModal.tsx
+++ b/lubee/src/fullpic/components/EmojiDetailModal.tsx
@@ -4,6 +4,7 @@ import { forwardRef } from "react";
 import getEmojiSrc from "@common/utils/getEmojiSrc";
 import getHoverProfileIconSrc from "@common/utils/getHoverProfileIconSrc";
 import { useGetOnePic } from "fullpic/hooks/useGetOnePic";
+import { useGetCouplesInfo } from "@common/hooks/useGetCouplesInfo";
 
 interface EmojiDetailModalProps {
   selectedEmojiText: string;
@@ -13,19 +14,20 @@ interface EmojiDetailModalProps {
 const EmojiDetailModal = forwardRef<HTMLDivElement, EmojiDetailModalProps>((props, ref) => {
   const { selectedEmojiText, memory_id } = props;
 
-  /* 서버한테 어떤 공감을 선택했는지 받아오면 됨*/
-  const { data: emojiData } = useGetOnePic(memory_id);
-  if (!emojiData) return <></>;
+  const { data: coupleInfo } = useGetCouplesInfo(); // 서버한테 어떤 프로필과 닉네임 선택했는지 받아오면 됨
+  const { data: emojiData } = useGetOnePic(memory_id); // 서버한테 어떤 공감을 선택했는지 받아오면 됨
+  if (!emojiData || !coupleInfo) return <></>;
 
   const myEmoji = getEmojiSrc("me", selectedEmojiText) || undefined; //내 이모지는 바뀔 수 있으니까 selected로
   const partnerEmoji = getEmojiSrc("partner", emojiData.response.reaction_second) || undefined;
 
-  const writerProfileFirst = emojiData.response.writer_profile_first;
-  const writerProfileSecond = emojiData.response.writer_profile_second;
+  const { nickname_first, profile_first, nickname_second, profile_second } = coupleInfo.response;
 
-  const isFirstWriter = writerProfileFirst !== null;
-  const myProfile = getHoverProfileIconSrc("me", isFirstWriter ? writerProfileFirst : writerProfileSecond);
-  const partnerProfile = getHoverProfileIconSrc("partner", isFirstWriter ? writerProfileSecond : writerProfileFirst);
+  const myProfile = getHoverProfileIconSrc("me", profile_first);
+  const partnerProfile = getHoverProfileIconSrc("partner", profile_second);
+
+  const myNickname = nickname_first;
+  const partnerNickname = nickname_second;
 
   return (
     <Background>
@@ -39,7 +41,7 @@ const EmojiDetailModal = forwardRef<HTMLDivElement, EmojiDetailModalProps>((prop
             <MyEmoji>
               <Profile>
                 <ProfileIcon as={myProfile} />
-                <Name>불꽃피카츄</Name>
+                <Name>{myNickname}</Name>
               </Profile>
               <EmojiIcon as={myEmoji} />
             </MyEmoji>
@@ -47,7 +49,7 @@ const EmojiDetailModal = forwardRef<HTMLDivElement, EmojiDetailModalProps>((prop
           <PartnerEmoji>
             <Profile>
               <ProfileIcon as={partnerProfile} />
-              <Name>맹꽁이</Name>
+              <Name>{partnerNickname}</Name>
             </Profile>
             <EmojiIcon as={partnerEmoji} />
           </PartnerEmoji>

--- a/lubee/src/fullpic/components/EmojiDetailModal.tsx
+++ b/lubee/src/fullpic/components/EmojiDetailModal.tsx
@@ -2,7 +2,7 @@ import { ShortBorderIc } from "assets/index";
 import styled from "styled-components";
 import { forwardRef } from "react";
 import getEmojiSrc from "@common/utils/getEmojiSrc";
-import getHoverProfileIconSrc from "@common/utils/getHoverProfileIconSrc";
+import getProfileIconSrc from "@common/utils/getProfileIconSrc";
 import { useGetOnePic } from "fullpic/hooks/useGetOnePic";
 import { useGetCouplesInfo } from "@common/hooks/useGetCouplesInfo";
 
@@ -23,8 +23,8 @@ const EmojiDetailModal = forwardRef<HTMLDivElement, EmojiDetailModalProps>((prop
 
   const { nickname_first, profile_first, nickname_second, profile_second } = coupleInfo.response;
 
-  const myProfile = getHoverProfileIconSrc("me", profile_first);
-  const partnerProfile = getHoverProfileIconSrc("partner", profile_second);
+  const myProfile = getProfileIconSrc("me", profile_first);
+  const partnerProfile = getProfileIconSrc("partner", profile_second);
 
   const myNickname = nickname_first;
   const partnerNickname = nickname_second;

--- a/lubee/src/fullpic/components/FullpicHeader.tsx
+++ b/lubee/src/fullpic/components/FullpicHeader.tsx
@@ -32,6 +32,7 @@ export default function FullpicHeader(props: FullpicHeaderProps) {
   }
 
   const prevPage = localStorage.getItem("currentPage");
+  console.log(prevPage);
 
   useEffect(() => {
     // 배열을 다시 로컬 스토리지에 저장

--- a/lubee/src/fullpic/components/FullpicHeader.tsx
+++ b/lubee/src/fullpic/components/FullpicHeader.tsx
@@ -32,7 +32,6 @@ export default function FullpicHeader(props: FullpicHeaderProps) {
   }
 
   const prevPage = localStorage.getItem("currentPage");
-  console.log(prevPage);
 
   useEffect(() => {
     // 배열을 다시 로컬 스토리지에 저장

--- a/lubee/src/fullpic/date/components/DateContainer.tsx
+++ b/lubee/src/fullpic/date/components/DateContainer.tsx
@@ -4,8 +4,9 @@ import EmojiBar from "@common/components/EmojiBar";
 import FullPicContainer from "@common/components/FullPicContainer";
 import EmojiTag from "@common/components/EmojiTag";
 import getEmojiSrc from "@common/utils/getEmojiSrc";
-import getProfileIconSrc from "@common/utils/getProfileIconSrc";
 import { MemoryBaseDtoDataTypes } from "fullpic/api/getOnePic";
+import getProfileIconSrc from "@common/utils/getHoverProfileIconSrc";
+import { useGetCouplesInfo } from "@common/hooks/useGetCouplesInfo";
 
 interface DateContainerProps {
   setOpenEmojiDetail: (open: boolean) => void;
@@ -67,16 +68,13 @@ export default function DateContainer(props: DateContainerProps) {
       {currentItems.map((data, index) => {
         const {
           memory_id: picMemoryId,
-          user_id,
           location_name,
           picture,
           writer_profile_first,
-          writer_profile_second,
           reaction_first,
           reaction_second,
           upload_time,
         } = data;
-        const profile = getProfileIconSrc("me", "profile2");
 
         useEffect(() => {
           if (reaction_first) {
@@ -87,12 +85,25 @@ export default function DateContainer(props: DateContainerProps) {
         const myEmoji = getEmojiSrc("me", selectedEmojiText) || undefined;
         const partnerEmoji = reaction_second ? getEmojiSrc("partner", reaction_second) : undefined;
 
+        const { data: coupleInfo } = useGetCouplesInfo();
+        if (!coupleInfo) return <></>;
+        const { nickname_first, profile_first, nickname_second, profile_second } = coupleInfo.response;
+
+        // account를 프로필이 null이 아닌 것으로 설정
+        const account = writer_profile_first !== null ? "me" : "partner";
+
+        // 작성자가 첫 번째 프로필이면 "me", 아니면 "partner"
+        const writerProfile =
+          account === "me" ? getProfileIconSrc("me", profile_first) : getProfileIconSrc("partner", profile_second);
+
+        const writerNickname = account === "me" ? nickname_first : nickname_second;
+
         return (
           <ContentsBox key={picMemoryId} ref={(el) => (itemRefs.current[index] = el)}>
             <Time>{upload_time}</Time>
             <Profile>
-              <ProfileIcon as={profile} />
-              <Name>{writer_profile_first}</Name>
+              <ProfileIcon as={writerProfile} />
+              <Name>{writerNickname}</Name>
             </Profile>
             <FullPicContainer picSrc={picture} location={location_name} />
             {(myEmoji || partnerEmoji) && (

--- a/lubee/src/fullpic/one/components/OneContainer.tsx
+++ b/lubee/src/fullpic/one/components/OneContainer.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import FullPicContainer from "@common/components/FullPicContainer";
 import { MemoryBaseDtoDataTypes } from "fullpic/api/getOnePic";
-import getHoverProfileIconSrc from "@common/utils/getHoverProfileIconSrc";
+import getProfileIconSrc from "@common/utils/getHoverProfileIconSrc";
 import { useGetCouplesInfo } from "@common/hooks/useGetCouplesInfo";
 
 interface OneContainerProps {
@@ -19,7 +19,7 @@ export default function OneContainer(props: OneContainerProps) {
 
   // 작성자가 첫 번째 프로필이면 "me", 아니면 "partner"
   const writerProfile =
-    account === "me" ? getHoverProfileIconSrc("me", profile_first) : getHoverProfileIconSrc("partner", profile_second);
+    account === "me" ? getProfileIconSrc("me", profile_first) : getProfileIconSrc("partner", profile_second);
 
   const writerNickname = account === "me" ? nickname_first : nickname_second;
 

--- a/lubee/src/fullpic/one/components/OneContainer.tsx
+++ b/lubee/src/fullpic/one/components/OneContainer.tsx
@@ -1,7 +1,8 @@
 import styled from "styled-components";
 import FullPicContainer from "@common/components/FullPicContainer";
-import getProfileIconSrc from "@common/utils/getProfileIconSrc";
 import { MemoryBaseDtoDataTypes } from "fullpic/api/getOnePic";
+import getHoverProfileIconSrc from "@common/utils/getHoverProfileIconSrc";
+import { useGetCouplesInfo } from "@common/hooks/useGetCouplesInfo";
 
 interface OneContainerProps {
   account: string;
@@ -10,15 +11,24 @@ interface OneContainerProps {
 
 export default function OneContainer(props: OneContainerProps) {
   const { account, memoryBaseDto } = props;
+  console.log(memoryBaseDto);
 
-  const profile = getProfileIconSrc(account, "profile1");
+  const { data: coupleInfo } = useGetCouplesInfo();
+  if (!coupleInfo) return <></>;
+  const { nickname_first, profile_first, nickname_second, profile_second } = coupleInfo.response;
+
+  // 작성자가 첫 번째 프로필이면 "me", 아니면 "partner"
+  const writerProfile =
+    account === "me" ? getHoverProfileIconSrc("me", profile_first) : getHoverProfileIconSrc("partner", profile_second);
+
+  const writerNickname = account === "me" ? nickname_first : nickname_second;
 
   return (
     <Wrapper>
       <Time>{memoryBaseDto.upload_time}</Time>
       <Profile>
-        <ProfileIcon as={profile} />
-        <Name>{memoryBaseDto.writer_profile}</Name>
+        <ProfileIcon as={writerProfile} />
+        <Name>{writerNickname}</Name>
       </Profile>
       <FullPicContainer picSrc={memoryBaseDto.picture} location={memoryBaseDto.location_name} />
     </Wrapper>

--- a/lubee/src/fullpic/one/index.tsx
+++ b/lubee/src/fullpic/one/index.tsx
@@ -68,6 +68,11 @@ export default function index() {
   if (!emojiData) return <></>;
   const { reaction_first } = emojiData.response;
   console.log(emojiData);
+
+  // account를 프로필이 null이 아닌 것으로 설정
+  const account = memoryBaseDto?.writer_profile_first !== null ? "me" : "partner";
+  console.log(memoryBaseDto);
+
   return (
     <Wrapper>
       <FullpicHeader
@@ -77,7 +82,7 @@ export default function index() {
         memory_id={memory_id}
         reaction_first={reaction_first}
       />
-      {memoryBaseDto && <OneContainer account="partner" memoryBaseDto={memoryBaseDto} />}
+      {memoryBaseDto && <OneContainer account={account} memoryBaseDto={memoryBaseDto} />}
       {(myEmoji || partnerEmoji) && (
         <EmojiTagContainer
           type="button"

--- a/lubee/src/fullpic/one/index.tsx
+++ b/lubee/src/fullpic/one/index.tsx
@@ -71,7 +71,6 @@ export default function index() {
 
   // account를 프로필이 null이 아닌 것으로 설정
   const account = memoryBaseDto?.writer_profile_first !== null ? "me" : "partner";
-  console.log(memoryBaseDto);
 
   return (
     <Wrapper>

--- a/lubee/src/home/month/components/DateDetailModal.tsx
+++ b/lubee/src/home/month/components/DateDetailModal.tsx
@@ -96,6 +96,7 @@ const Container = styled.section<{ $showCalendar: boolean }>`
   position: ${(props) => (props.$showCalendar ? "none" : "absolute")};
   bottom: 0;
   max-height: 49rem;
+  border-radius: 16px 16px 0 0;
   background-color: ${({ theme }) => theme.colors.white};
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */

--- a/lubee/src/home/month/components/MonthPicBox.tsx
+++ b/lubee/src/home/month/components/MonthPicBox.tsx
@@ -21,6 +21,8 @@ export default function MonthPicBox(props: MonthPicBoxProps) {
   const navigate = useNavigate();
   const { url, specificDto = [], year, month, selectedDate } = props;
 
+  localStorage.setItem("currentPage", "month"); // 컴포넌트가 렌더링될 때 "month"를 로컬 스토리지에 저장
+
   /* 서버한테 어떤 공감을 선택했는지 받아오면 됨*/
   const myEmojiIcon = (emoji: string | null) => {
     const emojiSrc = getEmojiSrc("me", emoji);
@@ -111,6 +113,7 @@ const Image = styled.img`
   height: 16.7rem;
   padding: 0;
   border: none;
+  border-radius: 12px;
   background: none;
 `;
 

--- a/lubee/src/home/month/components/MonthPicBox.tsx
+++ b/lubee/src/home/month/components/MonthPicBox.tsx
@@ -56,7 +56,7 @@ export default function MonthPicBox(props: MonthPicBoxProps) {
     <Container>
       {displayPics.map((img, index) => {
         const memory = specificDto.find((memory) => memory.memory_id === img.id);
-        const account = memory?.writer_profile_first !== null ? "me" : "partner";
+        const account = memory?.writer_profile_first !== null ? "me" : "partner"; // 작성자가 첫 번째 프로필이면 "me", 아니면 "partner"
         const writerProfile =
           account === "me"
             ? getProfileIconSrc("me", memory?.writer_profile_first || "")

--- a/lubee/src/home/month/components/MonthPicBox.tsx
+++ b/lubee/src/home/month/components/MonthPicBox.tsx
@@ -50,15 +50,19 @@ export default function MonthPicBox(props: MonthPicBoxProps) {
           partnerEmoji: memory.reaction_second,
         }));
 
-  /*프로필 아이콘*/
-  const myProfile = getProfileIconSrc("me", "profile1");
-
   const monthHeader = monthHeaderDateFormat(year, month, selectedDate);
 
   return (
     <Container>
-      {displayPics.map((img, index) =>
-        img.picSrc === blankImg && selectedDate != undefined ? (
+      {displayPics.map((img, index) => {
+        const memory = specificDto.find((memory) => memory.memory_id === img.id);
+        const account = memory?.writer_profile_first !== null ? "me" : "partner";
+        const writerProfile =
+          account === "me"
+            ? getProfileIconSrc("me", memory?.writer_profile_first || "")
+            : getProfileIconSrc("partner", memory?.writer_profile_second || "");
+
+        return img.picSrc === blankImg && selectedDate != undefined ? (
           <BlankImgBtn key={img.id} index={index} year={year} month={month} day={selectedDate} />
         ) : (
           <ImgContainer
@@ -70,12 +74,9 @@ export default function MonthPicBox(props: MonthPicBoxProps) {
               });
             }}>
             <Image src={img.picSrc} />
-            <ProfileIcon as={myProfile} />
+            <ProfileIcon as={writerProfile} />
             <TagContainer>
-              <LocationTag
-                location={specificDto.find((memory) => memory.memory_id === img.id)?.location_name || ""}
-                font="smallPic"
-              />
+              <LocationTag location={memory?.location_name || ""} font="smallPic" />
               {img.myEmoji || img.partnerEmoji ? (
                 <EmojiTag font="smallPic">
                   {myEmojiIcon(img.myEmoji)}
@@ -84,8 +85,8 @@ export default function MonthPicBox(props: MonthPicBoxProps) {
               ) : null}
             </TagContainer>
           </ImgContainer>
-        ),
-      )}
+        );
+      })}
     </Container>
   );
 }

--- a/lubee/src/home/today/components/TodayPicBox.tsx
+++ b/lubee/src/home/today/components/TodayPicBox.tsx
@@ -18,6 +18,8 @@ export default function TodayPicBox(props: TodayPicBoxProps) {
   const navigate = useNavigate();
   const { url, specificDto = [] } = props;
 
+  localStorage.setItem("currentPage", "today"); // 컴포넌트가 렌더링될 때 "today"를 로컬 스토리지에 저장
+
   /*이미지 개수가 5개 이하이면 이미지 추가하는 버튼 만들어주는 array*/
   const displayPics =
     specificDto.length < 5
@@ -106,6 +108,7 @@ const Image = styled.img`
   height: 16.7rem;
   padding: 0;
   border: none;
+  border-radius: 12px;
   background: none;
 `;
 

--- a/lubee/src/home/today/components/TodayPicBox.tsx
+++ b/lubee/src/home/today/components/TodayPicBox.tsx
@@ -37,9 +37,6 @@ export default function TodayPicBox(props: TodayPicBoxProps) {
           partnerEmoji: memory.reaction_second,
         }));
 
-  /*프로필 아이콘*/
-  const myProfile = getProfileIconSrc("me", "profile1");
-
   /*리액션 아이콘*/
   const myEmojiIcon = (emoji: string | null) => {
     const emojiSrc = getEmojiSrc("me", emoji);
@@ -52,8 +49,15 @@ export default function TodayPicBox(props: TodayPicBoxProps) {
 
   return (
     <Container>
-      {displayPics.map((img, index) =>
-        img.picSrc === blankImg ? (
+      {displayPics.map((img, index) => {
+        const memory = specificDto.find((memory) => memory.memory_id === img.id);
+        const account = memory?.writer_profile_first !== null ? "me" : "partner"; // 작성자가 첫 번째 프로필이면 "me", 아니면 "partner"
+        const writerProfile =
+          account === "me"
+            ? getProfileIconSrc("me", memory?.writer_profile_first || "")
+            : getProfileIconSrc("partner", memory?.writer_profile_second || "");
+
+        return img.picSrc === blankImg ? (
           <BlankImgBtn key={img.id} index={index} year={getTodayYear} month={getTodayMonth} day={getTodayDate} />
         ) : (
           <ImgContainer
@@ -65,12 +69,9 @@ export default function TodayPicBox(props: TodayPicBoxProps) {
               });
             }}>
             <Image src={img.picSrc} />
-            <ProfileIcon as={myProfile} />
+            <ProfileIcon as={writerProfile} />
             <TagContainer>
-              <LocationTag
-                location={specificDto.find((memory) => memory.memory_id === img.id)?.location_name || ""}
-                font="smallPic"
-              />
+              <LocationTag location={memory?.location_name || ""} font="smallPic" />
               {img.myEmoji || img.partnerEmoji ? (
                 <EmojiTag font="smallPic">
                   {myEmojiIcon(img.myEmoji)}
@@ -79,8 +80,8 @@ export default function TodayPicBox(props: TodayPicBoxProps) {
               ) : null}
             </TagContainer>
           </ImgContainer>
-        ),
-      )}
+        );
+      })}
     </Container>
   );
 }

--- a/lubee/src/home/today/components/TodayTitle.tsx
+++ b/lubee/src/home/today/components/TodayTitle.tsx
@@ -11,13 +11,13 @@ export default function TodayTitle(props: TodayTitleProps) {
   if (!CoupleInfo) return <></>;
 
   const {
-    response: { nickname_first },
+    response: { nickname_second },
   } = CoupleInfo;
 
   return (
     <Container>
       <DateText>
-        {nickname_first} 님과 <NumberText>{day}</NumberText>일 째{"\n"}꿀 모으는 날
+        {nickname_second} 님과 <NumberText>{day}</NumberText>일 째{"\n"}꿀 모으는 날
       </DateText>
     </Container>
   );

--- a/lubee/src/loading/index.tsx
+++ b/lubee/src/loading/index.tsx
@@ -30,8 +30,8 @@ export default function index() {
             return;
           }
 
+          // 꿀 개수가 이전보다 증가한 경우
           if (response > previousHoney) {
-            // 꿀 개수가 이전보다 증가한 경우
             if (response === 1) {
               navigate("/congrats/first");
             } else if (response === 5) {
@@ -52,19 +52,14 @@ export default function index() {
               navigate("/home/month");
             }
           }
+
           // 이전 꿀 개수 업데이트
           setPreviousHoney(response);
           localStorage.setItem("previousHoney", JSON.stringify(response));
         }
       } catch (error) {
-        // 오류가 발생한 경우 기본 페이지로 이동
         console.error("Error fetching honey count:", error);
-        const prevPage = localStorage.getItem("currentPage");
-        if (prevPage === "today") {
-          navigate("/home/today");
-        } else {
-          navigate("/home/month");
-        }
+        navigate("/home/today");
       }
     };
 

--- a/lubee/src/mypage/components/HoneyBox.tsx
+++ b/lubee/src/mypage/components/HoneyBox.tsx
@@ -11,13 +11,15 @@ export default function HoneyBox(props: HoneyBoxProps) {
   const total = 50;
   const percentage = (count / total) * 100;
 
+  const rest = total - count;
+
   return (
     <Container>
       <HoneyContainer>
         <TitleContainer>
           <HoneyYellowIcon />
           <TitleText>전체 꿀 {count}개</TitleText>
-          <SubtitleText>리와인드까지 25개</SubtitleText>
+          <SubtitleText>리와인드까지 {rest}개</SubtitleText>
         </TitleContainer>
         <ProgressContainer>
           <ProgressBarContainer>


### PR DESCRIPTION
## Related Issues

- close #85 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 변경 사항 in Detail

- [x] 각자 작성자 프로필을 출력해야하는 부분 모두 적용
  - MonthPicBox
  - TodayPicBox
  - fullpic 페이지
  - EmojiDetailModal
```
        const { data: coupleInfo } = useGetCouplesInfo();
        if (!coupleInfo) return <></>;
        const { nickname_first, profile_first, nickname_second, profile_second } = coupleInfo.response;

        // account를 프로필이 null이 아닌 것으로 설정
        const account = writer_profile_first !== null ? "me" : "partner";

        // 작성자가 첫 번째 프로필이면 "me", 아니면 "partner"
        const writerProfile =
          account === "me" ? getProfileIconSrc("me", profile_first) : getProfileIconSrc("partner", profile_second);

        const writerNickname = account === "me" ? nickname_first : nickname_second;
```

- [x] 홈_오늘에서 "맹꽁이 님과 337일째 꿀 모으는 날"에서 상대 이름이 출력되도록 변경했어!

- [x] TodayPicBox, MonthPicBox에서 뒤로가기 클릭 시 월간탭으로 이동해서 각자 today와 month를 로컬스토리지에 currentPage로 저장했어!

 
https://github.com/user-attachments/assets/ea50c89a-18cb-47b2-bfb6-bd9606bbbd73

## 다음에 할 것

- [ ] 홈_오늘에서 플러스 버튼 클릭으로 오늘 기록 눌러서 기록 업로드
