### PR TITLE
home 페이지 기능 QA

### DIFF
--- a/lubee/src/assets/icon/leftArrowIc.svg
+++ b/lubee/src/assets/icon/leftArrowIc.svg
@@ -1,0 +1,5 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="rightArrowBigIc">
+<path id="Vector 25907" d="M35 45.5L17.5 28L35 10.5" stroke="#AFB3C0" stroke-width="4.08333" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/lubee/src/assets/icon/leftArrowIc.svg
+++ b/lubee/src/assets/icon/leftArrowIc.svg
@@ -1,5 +1,3 @@
 <svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="rightArrowBigIc">
-<path id="Vector 25907" d="M35 45.5L17.5 28L35 10.5" stroke="#AFB3C0" stroke-width="4.08333" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
+<path d="M35 45.5L17.5 28L35 10.5" stroke="#242424" stroke-width="4.08333" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/lubee/src/assets/icon/rightArrowIc.svg
+++ b/lubee/src/assets/icon/rightArrowIc.svg
@@ -1,5 +1,3 @@
 <svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="rightArrowBigIc">
-<path id="Vector 25907" d="M19 46L37 28L19 10" stroke="#9196A7" stroke-width="2.91667" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
+<path d="M19 46L37 28L19 10" stroke="#242424" stroke-width="2.91667" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/lubee/src/assets/icon/rightArrowIc.svg
+++ b/lubee/src/assets/icon/rightArrowIc.svg
@@ -1,0 +1,5 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="rightArrowBigIc">
+<path id="Vector 25907" d="M19 46L37 28L19 10" stroke="#9196A7" stroke-width="2.91667" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/lubee/src/assets/index.ts
+++ b/lubee/src/assets/index.ts
@@ -84,6 +84,8 @@ import TodayHoney2Ic from "./icon/todayHoney2Ic.svg?react";
 import TodayHoney3Ic from "./icon/todayHoney3Ic.svg?react";
 import TodayHoney4Ic from "./icon/todayHoney4Ic.svg?react";
 import TodayHoney5Ic from "./icon/todayHoney5Ic.svg?react";
+import RightArrowIc from "./icon/rightArrowIc.svg?react";
+import LeftArrowIc from "./icon/leftArrowIc.svg?react";
 
 export {
   LogoIc,
@@ -172,4 +174,6 @@ export {
   TodayHoney3Ic,
   TodayHoney4Ic,
   TodayHoney5Ic,
+  RightArrowIc,
+  LeftArrowIc,
 };

--- a/lubee/src/error/index.tsx
+++ b/lubee/src/error/index.tsx
@@ -1,3 +1,45 @@
+import styled from "styled-components";
+
+import CompanyText from "@common/components/CompanyText";
+import { SymbolIc } from "assets";
+
 export default function index() {
-  return <div>에러 발생</div>;
+  return (
+    <Wrapper>
+      <LogoContainer>
+        <SymbolIcon />
+        <Text>Error...</Text>
+      </LogoContainer>
+      <CompanyText />
+    </Wrapper>
+  );
 }
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+const LogoContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+  align-items: center;
+  margin-top: 27.8rem;
+`;
+
+const Text = styled.p`
+  ${({ theme }) => theme.fonts.Body_0};
+
+  color: ${({ theme }) => theme.colors.gray_700};
+`;
+
+const SymbolIcon = styled(SymbolIc)`
+  width: 4.6rem;
+  height: 4.6rem;
+`;

--- a/lubee/src/fullpic/components/EmojiDetailModal.tsx
+++ b/lubee/src/fullpic/components/EmojiDetailModal.tsx
@@ -41,13 +41,15 @@ const EmojiDetailModal = forwardRef<HTMLDivElement, EmojiDetailModalProps>((prop
               <EmojiIcon as={myEmoji} />
             </MyEmoji>
           )}
-          <PartnerEmoji>
-            <Profile>
-              <ProfileIcon as={partnerProfile} />
-              <Name>맹꽁이</Name>
-            </Profile>
-            <EmojiIcon as={partnerEmoji} />
-          </PartnerEmoji>
+          {partnerEmoji && (
+            <PartnerEmoji>
+              <Profile>
+                <ProfileIcon as={partnerProfile} />
+                <Name>맹꽁이</Name>
+              </Profile>
+              <EmojiIcon as={partnerEmoji} />
+            </PartnerEmoji>
+          )}
         </EmojiBox>
       </Container>
     </Background>

--- a/lubee/src/fullpic/date/components/DateContainer.tsx
+++ b/lubee/src/fullpic/date/components/DateContainer.tsx
@@ -6,7 +6,6 @@ import EmojiTag from "@common/components/EmojiTag";
 import getEmojiSrc from "@common/utils/getEmojiSrc";
 import getProfileIconSrc from "@common/utils/getProfileIconSrc";
 import { MemoryBaseDtoDataTypes } from "fullpic/api/getOnePic";
-import { LeftArrowIc, RightArrowIc } from "assets";
 
 interface DateContainerProps {
   setOpenEmojiDetail: (open: boolean) => void;
@@ -116,12 +115,17 @@ export default function DateContainer(props: DateContainerProps) {
           </ContentsBox>
         );
       })}
-      <LeftButton onClick={handlePrevPage} disabled={currentPage === 0}>
-        <LeftArrowIcon />
-      </LeftButton>
-      <RightButton onClick={handleNextPage} disabled={currentPage === totalPages - 1}>
-        <RightArrowIcon />
-      </RightButton>
+      <Pagination>
+        <PageButton onClick={handlePrevPage} disabled={currentPage === 0}>
+          {"<"}
+        </PageButton>
+        <PageIndicator>
+          {currentPage + 1} / {totalPages}
+        </PageIndicator>
+        <PageButton onClick={handleNextPage} disabled={currentPage === totalPages - 1}>
+          {">"}
+        </PageButton>
+      </Pagination>
     </Wrapper>
   );
 }
@@ -187,47 +191,28 @@ const EmojiIcon = styled.svg`
   height: 2.4rem;
 `;
 
-// const Pagination = styled.div`
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-//   margin-top: 1rem;
-// `;
+const Pagination = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
-const LeftButton = styled.button`
-  position: absolute;
-  top: 25rem;
-  left: 2rem;
-  padding: 0;
-  border: none;
-  background: none;
+const PageButton = styled.button`
+  padding: 0.2rem 0.5rem;
+  border-radius: 5px;
+  background-color: ${({ theme }) => theme.colors.yellow};
+  color: ${({ theme }) => theme.colors.white};
   cursor: pointer;
 
   &:disabled {
+    background-color: ${({ theme }) => theme.colors.gray_50};
     cursor: not-allowed;
   }
 `;
 
-const RightButton = styled.button`
-  position: absolute;
-  top: 25rem;
-  right: 2rem;
-  padding: 0;
-  border: none;
-  background: none;
-  cursor: pointer;
+const PageIndicator = styled.span`
+  margin: 0 1rem;
+  ${({ theme }) => theme.fonts.Body_3}
 
-  &:disabled {
-    cursor: not-allowed;
-  }
-`;
-
-const RightArrowIcon = styled(RightArrowIc)`
-  width: 5rem;
-  height: 5rem;
-`;
-
-const LeftArrowIcon = styled(LeftArrowIc)`
-  width: 5rem;
-  height: 5rem;
+  color: ${({ theme }) => theme.colors.gray_900};
 `;

--- a/lubee/src/fullpic/date/components/DateContainer.tsx
+++ b/lubee/src/fullpic/date/components/DateContainer.tsx
@@ -6,6 +6,7 @@ import EmojiTag from "@common/components/EmojiTag";
 import getEmojiSrc from "@common/utils/getEmojiSrc";
 import getProfileIconSrc from "@common/utils/getProfileIconSrc";
 import { MemoryBaseDtoDataTypes } from "fullpic/api/getOnePic";
+import { LeftArrowIc, RightArrowIc } from "assets";
 
 interface DateContainerProps {
   setOpenEmojiDetail: (open: boolean) => void;
@@ -115,17 +116,12 @@ export default function DateContainer(props: DateContainerProps) {
           </ContentsBox>
         );
       })}
-      <Pagination>
-        <PageButton onClick={handlePrevPage} disabled={currentPage === 0}>
-          {"<"}
-        </PageButton>
-        <PageIndicator>
-          {currentPage + 1} / {totalPages}
-        </PageIndicator>
-        <PageButton onClick={handleNextPage} disabled={currentPage === totalPages - 1}>
-          {">"}
-        </PageButton>
-      </Pagination>
+      <LeftButton onClick={handlePrevPage} disabled={currentPage === 0}>
+        <LeftArrowIcon />
+      </LeftButton>
+      <RightButton onClick={handleNextPage} disabled={currentPage === totalPages - 1}>
+        <RightArrowIcon />
+      </RightButton>
     </Wrapper>
   );
 }
@@ -191,29 +187,47 @@ const EmojiIcon = styled.svg`
   height: 2.4rem;
 `;
 
-const Pagination = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: 1rem;
-`;
+// const Pagination = styled.div`
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+//   margin-top: 1rem;
+// `;
 
-const PageButton = styled.button`
-  padding: 0.2rem 0.5rem;
-  border-radius: 5px;
-  background-color: ${({ theme }) => theme.colors.yellow};
-  color: ${({ theme }) => theme.colors.white};
+const LeftButton = styled.button`
+  position: absolute;
+  top: 25rem;
+  left: 2rem;
+  padding: 0;
+  border: none;
+  background: none;
   cursor: pointer;
 
   &:disabled {
-    background-color: ${({ theme }) => theme.colors.gray_50};
     cursor: not-allowed;
   }
 `;
 
-const PageIndicator = styled.span`
-  margin: 0 1rem;
-  ${({ theme }) => theme.fonts.Body_3}
+const RightButton = styled.button`
+  position: absolute;
+  top: 25rem;
+  right: 2rem;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
 
-  color: ${({ theme }) => theme.colors.gray_900};
+  &:disabled {
+    cursor: not-allowed;
+  }
+`;
+
+const RightArrowIcon = styled(RightArrowIc)`
+  width: 5rem;
+  height: 5rem;
+`;
+
+const LeftArrowIcon = styled(LeftArrowIc)`
+  width: 5rem;
+  height: 5rem;
 `;

--- a/lubee/src/fullpic/date/components/DateContainer.tsx
+++ b/lubee/src/fullpic/date/components/DateContainer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import styled from "styled-components";
 import EmojiBar from "@common/components/EmojiBar";
 import FullPicContainer from "@common/components/FullPicContainer";
@@ -13,15 +13,22 @@ interface DateContainerProps {
   setSelectedEmojiText: (text: string) => void;
   specificDto: MemoryBaseDtoDataTypes[];
   memory_id: number;
-  setMemoryId: (id: number) => void;
+  currentPage: number;
+  setCurrentPage: (page: number) => void;
+  itemsPerPage: number;
 }
 
 export default function DateContainer(props: DateContainerProps) {
-  const { setOpenEmojiDetail, selectedEmojiText, setSelectedEmojiText, specificDto, memory_id, setMemoryId } = props;
-  /*페이지 네이션*/
-  const [currentPage, setCurrentPage] = useState(0);
-  const itemsPerPage = 1;
-  const totalPages = Math.ceil(specificDto.length / itemsPerPage);
+  const {
+    setOpenEmojiDetail,
+    selectedEmojiText,
+    setSelectedEmojiText,
+    specificDto,
+    memory_id,
+    currentPage,
+    setCurrentPage,
+    itemsPerPage,
+  } = props;
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   // memory_id와 일치하는 페이지
@@ -43,22 +50,6 @@ export default function DateContainer(props: DateContainerProps) {
       });
     }
   }, [currentPage, memory_id, specificDto, itemsPerPage]);
-
-  const handlePrevPage = () => {
-    if (currentPage > 0) {
-      const newPage = currentPage - 1;
-      setCurrentPage(newPage);
-      setMemoryId(specificDto[newPage * itemsPerPage].memory_id);
-    }
-  };
-
-  const handleNextPage = () => {
-    if (currentPage < totalPages - 1) {
-      const newPage = currentPage + 1;
-      setCurrentPage(newPage);
-      setMemoryId(specificDto[newPage * itemsPerPage].memory_id);
-    }
-  };
 
   const currentItems = specificDto.slice(currentPage * itemsPerPage, (currentPage + 1) * itemsPerPage);
 
@@ -115,17 +106,6 @@ export default function DateContainer(props: DateContainerProps) {
           </ContentsBox>
         );
       })}
-      <Pagination>
-        <PageButton onClick={handlePrevPage} disabled={currentPage === 0}>
-          {"<"}
-        </PageButton>
-        <PageIndicator>
-          {currentPage + 1} / {totalPages}
-        </PageIndicator>
-        <PageButton onClick={handleNextPage} disabled={currentPage === totalPages - 1}>
-          {">"}
-        </PageButton>
-      </Pagination>
     </Wrapper>
   );
 }
@@ -141,7 +121,6 @@ const ContentsBox = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 2rem;
 `;
 
 const Time = styled.p`
@@ -189,30 +168,4 @@ const Footer = styled.div`
 const EmojiIcon = styled.svg`
   width: 2.4rem;
   height: 2.4rem;
-`;
-
-const Pagination = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
-const PageButton = styled.button`
-  padding: 0.2rem 0.5rem;
-  border-radius: 5px;
-  background-color: ${({ theme }) => theme.colors.yellow};
-  color: ${({ theme }) => theme.colors.white};
-  cursor: pointer;
-
-  &:disabled {
-    background-color: ${({ theme }) => theme.colors.gray_50};
-    cursor: not-allowed;
-  }
-`;
-
-const PageIndicator = styled.span`
-  margin: 0 1rem;
-  ${({ theme }) => theme.fonts.Body_3}
-
-  color: ${({ theme }) => theme.colors.gray_900};
 `;

--- a/lubee/src/fullpic/date/index.tsx
+++ b/lubee/src/fullpic/date/index.tsx
@@ -7,6 +7,7 @@ import FullpicHeader from "fullpic/components/FullpicHeader";
 import { useLocation } from "react-router-dom";
 import { MemoryBaseDtoDataTypes } from "fullpic/api/getOnePic";
 import { useGetOnePic } from "fullpic/hooks/useGetOnePic";
+import { LeftArrowIc, RightArrowIc } from "assets";
 
 export default function index() {
   const [openDeletePicModal, setOpenDeletePicModal] = useState<boolean>(false);
@@ -17,6 +18,9 @@ export default function index() {
   const { memory_id } = location.state as { memory_id: number };
 
   const [memoryId, setMemoryId] = useState<number>(memory_id);
+  const [currentPage, setCurrentPage] = useState(0);
+  const itemsPerPage = 1;
+  const totalPages = Math.ceil(specificDto.length / itemsPerPage);
 
   function handleTrashBtn(open: boolean) {
     setOpenDeletePicModal(open);
@@ -41,6 +45,23 @@ export default function index() {
   if (!emojiData) return <></>;
   const { reaction_first } = emojiData.response;
 
+  /*페이지 네이션*/
+  const handlePrevPage = () => {
+    if (currentPage > 0) {
+      const newPage = currentPage - 1;
+      setCurrentPage(newPage);
+      setMemoryId(specificDto[newPage * itemsPerPage].memory_id);
+    }
+  };
+
+  const handleNextPage = () => {
+    if (currentPage < totalPages - 1) {
+      const newPage = currentPage + 1;
+      setCurrentPage(newPage);
+      setMemoryId(specificDto[newPage * itemsPerPage].memory_id);
+    }
+  };
+
   return (
     <Wrapper>
       <FullpicHeader
@@ -56,8 +77,20 @@ export default function index() {
         selectedEmojiText={selectedEmojiText}
         specificDto={specificDto}
         memory_id={memory_id}
-        setMemoryId={setMemoryId}
+        currentPage={currentPage}
+        itemsPerPage={itemsPerPage}
+        setCurrentPage={setCurrentPage}
       />
+      {currentPage !== 0 ? (
+        <LeftPageButton onClick={handlePrevPage}>
+          <LeftArrowIcon />
+        </LeftPageButton>
+      ) : null}
+      {currentPage !== totalPages - 1 ? (
+        <RightPageButton onClick={handleNextPage}>
+          <RightArrowIcon />
+        </RightPageButton>
+      ) : null}
       {openDeletePicModal && <DeletePicModal handleTrashBtn={handleTrashBtn} memory_id={memoryId} />}
       {openEmojiDetail && (
         <EmojiDetailModal ref={modalRef} selectedEmojiText={selectedEmojiText} memory_id={memoryId} />
@@ -77,4 +110,32 @@ const Wrapper = styled.section`
   &::-webkit-scrollbar {
     display: none; /* Chrome, Safari, Opera */
   }
+`;
+
+const LeftPageButton = styled.button`
+  position: absolute;
+  top: 31rem;
+  left: 1.5rem;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+`;
+
+const RightPageButton = styled.button`
+  position: absolute;
+  top: 31rem;
+  right: 1.5rem;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+`;
+
+const LeftArrowIcon = styled(LeftArrowIc)`
+  width: 3rem;
+  height: 3rem;
+`;
+
+const RightArrowIcon = styled(RightArrowIc)`
+  width: 3rem;
+  height: 3rem;
 `;

--- a/lubee/src/home/hooks/useGetCalendar.ts
+++ b/lubee/src/home/hooks/useGetCalendar.ts
@@ -2,10 +2,10 @@ import { useQuery } from "react-query";
 import { getCalendar } from "home/api/getCalendar";
 
 export function useGetCalendar() {
-  const { data } = useQuery("getCalendar", () => getCalendar(), {
+  const { data, refetch } = useQuery("getCalendar", () => getCalendar(), {
     onError: (error) => {
       console.log("에러 발생", error);
     },
   });
-  return data;
+  return { data, refetch };
 }

--- a/lubee/src/home/month/components/CalContainer.tsx
+++ b/lubee/src/home/month/components/CalContainer.tsx
@@ -22,7 +22,7 @@ const CalContainer = ({ info, showCalendar = false, setOpenDateDetailModal }: Ca
   const { year, month, start, length } = info;
   const [list, setList] = useState<number[]>(new Array(start + length).fill(0)); // LIST 초기화
 
-  const calendarData = useGetCalendar();
+  const { data: calendarData, refetch: refetchCalendarData } = useGetCalendar();
   const totalHoney = useGetMonthHoney(year, month);
 
   useEffect(() => {
@@ -57,9 +57,14 @@ const CalContainer = ({ info, showCalendar = false, setOpenDateDetailModal }: Ca
         }
       });
 
-      setList(updatedList); // Update the state with the new list only once
+      setList(updatedList);
     }
   }, [calendarData, year, month, start, length]);
+
+  // calendarData가 바뀔 때마다 useGetCalendar refetch
+  useEffect(() => {
+    refetchCalendarData();
+  }, [calendarData, refetchCalendarData]);
 
   function handleDateDetailModal(date: number) {
     if (isFutureDate(year, month, date)) {

--- a/lubee/src/home/month/components/MonthHomeHeader.tsx
+++ b/lubee/src/home/month/components/MonthHomeHeader.tsx
@@ -1,29 +1,21 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 
 export default function MonthHomeHeader() {
   const navigate = useNavigate();
-  const [currentPage, setCurrentPage] = useState<string>(() => {
-    return localStorage.getItem("currentPage") || "today";
-  });
 
   useEffect(() => {
-    localStorage.setItem("currentPage", currentPage);
-  }, [currentPage]);
+    localStorage.setItem("currentPage", "month");
+  }, []);
 
   function moveToHomeToday() {
     navigate("/home/today");
-    setCurrentPage("today");
   }
 
   function moveToHomeMonth() {
     navigate("/home/month");
-    setCurrentPage("month");
   }
-
-  // removeToken();
-  // console.log(getToken());
 
   return (
     <Container>

--- a/lubee/src/home/month/components/MonthPicBox.tsx
+++ b/lubee/src/home/month/components/MonthPicBox.tsx
@@ -124,6 +124,7 @@ const ProfileIcon = styled.svg`
 const TagContainer = styled.div`
   display: flex;
   gap: 0.4rem;
+  align-items: flex-end;
   position: absolute;
   bottom: 1.2rem;
   left: 1.21rem;

--- a/lubee/src/home/month/components/MonthPicBox.tsx
+++ b/lubee/src/home/month/components/MonthPicBox.tsx
@@ -109,7 +109,7 @@ const Image = styled.img`
   width: 16.7rem;
   height: 16.7rem;
   padding: 0;
-  border: none;
+  border-radius: 20px;
   background: none;
 `;
 

--- a/lubee/src/home/month/index.tsx
+++ b/lubee/src/home/month/index.tsx
@@ -4,7 +4,6 @@ import { CAL } from "@common/core/calendarData";
 import { getTodayMonth, getTodayYear } from "@common/utils/dateFormat";
 import { useEffect, useRef } from "react";
 import MonthHomeHeader from "./components/MonthHomeHeader";
-import { Suspense } from "react";
 
 export default function index() {
   /*이번 달 상단에 위치시키는 ref*/
@@ -24,16 +23,14 @@ export default function index() {
 
   return (
     <>
-      <Suspense fallback={<div>로딩중</div>}>
-        <MonthHomeHeader />
-        <CalWrapper ref={containerRef}>
-          {CAL.map((cal, idx) => (
-            <div key={idx} ref={(el) => (calendarRefs.current[idx] = el)}>
-              <CalContainer info={cal} />
-            </div>
-          ))}
-        </CalWrapper>
-      </Suspense>
+      <MonthHomeHeader />
+      <CalWrapper ref={containerRef}>
+        {CAL.map((cal, idx) => (
+          <div key={idx} ref={(el) => (calendarRefs.current[idx] = el)}>
+            <CalContainer info={cal} />
+          </div>
+        ))}
+      </CalWrapper>
     </>
   );
 }

--- a/lubee/src/home/today/components/TodayHomeHeader.tsx
+++ b/lubee/src/home/today/components/TodayHomeHeader.tsx
@@ -1,29 +1,21 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 
 export default function TodayHomeHeader() {
   const navigate = useNavigate();
-  const [currentPage, setCurrentPage] = useState<string>(() => {
-    return localStorage.getItem("currentPage") || "today";
-  });
 
   useEffect(() => {
-    localStorage.setItem("currentPage", currentPage);
-  }, [currentPage]);
+    localStorage.setItem("currentPage", "today");
+  }, []);
 
   function moveToHomeToday() {
     navigate("/home/today");
-    setCurrentPage("today");
   }
 
   function moveToHomeMonth() {
     navigate("/home/month");
-    setCurrentPage("month");
   }
-
-  // removeToken();
-  // console.log(getToken());
 
   return (
     <Container>

--- a/lubee/src/home/today/components/TodayPicBox.tsx
+++ b/lubee/src/home/today/components/TodayPicBox.tsx
@@ -104,7 +104,7 @@ const Image = styled.img`
   width: 16.7rem;
   height: 16.7rem;
   padding: 0;
-  border: none;
+  border-radius: 20px;
   background: none;
 `;
 

--- a/lubee/src/mypage/components/MypageProfileBox.tsx
+++ b/lubee/src/mypage/components/MypageProfileBox.tsx
@@ -1,7 +1,5 @@
 import styled from "styled-components";
 import { XIc, EditIc } from "assets/index";
-import getHoverProfileIconSrc from "@common/utils/getHoverProfileIconSrc";
-
 interface MypageProfileBoxProps {
   myName: string;
   myBirth: string;

--- a/lubee/src/upload/components/SelectLocationModal.tsx
+++ b/lubee/src/upload/components/SelectLocationModal.tsx
@@ -16,15 +16,10 @@ export default function SelectLocationModal(props: SelectLocationModalProps) {
   const { setOpenLocationModal, setLocation, searchInput, setSearchInput, setLocationId } = props;
 
   /* 장소 불러오기 API*/
-  const debouncedSearchInput = useDebounce(searchInput, 1000);
+  const debouncedSearchInput = useDebounce(searchInput, 300);
   const locationSearch = useGetLocationSearch({ keyword: debouncedSearchInput });
 
-  // Guard clause to prevent rendering when locationSearch is undefined or has errors
-  if (!locationSearch || !locationSearch.response) return <></>;
-
-  const {
-    response: { locations },
-  } = locationSearch;
+  const locations = locationSearch?.response?.locations ?? [];
 
   function closeLocationModal(locationName?: string, locationId?: number) {
     setOpenLocationModal(false);
@@ -62,7 +57,6 @@ export default function SelectLocationModal(props: SelectLocationModalProps) {
                 <LocationBox key={locationId} type="button" onClick={() => closeLocationModal(name, locationId)}>
                   <Name>{name}</Name>
                   <Details>
-                    {/* <Distance>{`${distance}m,`}</Distance> */}
                     <Info>{parcelBaseAddress}</Info>
                   </Details>
                 </LocationBox>

--- a/lubee/src/upload/hooks/useGetLocationSearch.ts
+++ b/lubee/src/upload/hooks/useGetLocationSearch.ts
@@ -3,7 +3,7 @@ import { getLocationSearch, LocationSearchParams } from "../api/getLocationSearc
 
 export function useGetLocationSearch({ keyword }: LocationSearchParams) {
   const { data } = useQuery(["getLocationSearch", keyword], () => getLocationSearch({ keyword }), {
-    enabled: !!keyword, // keyword가 empty가 아닐때만 query
+    enabled: keyword !== "", // keyword가 empty가 아닐때만 query
     onError: (error) => {
       console.log("에러", error);
     },

--- a/lubee/src/upload/location/index.tsx
+++ b/lubee/src/upload/location/index.tsx
@@ -65,7 +65,6 @@ export default function index(props: LocationProps) {
               <LocationBox key={locationId} type="button" onClick={() => handleSelectLocation(name, locationId)}>
                 <Name>{name}</Name>
                 <Details>
-                  {/* <Distance>{`${distance}m,`}</Distance> */}
                   <Info>{parcelBaseAddress}</Info>
                 </Details>
               </LocationBox>

--- a/lubee/src/upload/pic/index.tsx
+++ b/lubee/src/upload/pic/index.tsx
@@ -38,7 +38,7 @@ export default function index(props: UploadProps) {
   const uploadMonth = locationState.state.month;
   const uploadDay = locationState.state.day;
 
-  console.log(picSrc);
+  console.log(openLocationModal);
   const { mutate: postUploadPic } = usePostUploadPic();
 
   return (


### PR DESCRIPTION
## Related Issues

- close #88 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 오류 수정
- [x] CSS 등 스타일 변경

## 변경 사항 in Detail

- [x] fullpic/month 디자인 변경
  - position 값을 주어서 하단에 버튼이 아닌 이미지안에 좌우로 움직이는 화살표 버튼이 위치하게 수정 
<img width="380" alt="스크린샷 2024-07-29 오후 6 35 27" src="https://github.com/user-attachments/assets/977d5534-e4ce-41ae-8130-edd836796bcc">

- [x] 기존 탭이 오늘, 월간이었는지에 따라 fullpic사진을 본 뒤 다시 home으로 뒤돌아갈때 반영

- [x] location 검색에서 키워드가 ""인경우 서버와 통신을 보내지 않도록 

```js
export function useGetLocationSearch({ keyword }: LocationSearchParams) {
  const { data } = useQuery(["getLocationSearch", keyword], () => getLocationSearch({ keyword }), {
    enabled: keyword !== "", // keyword가 empty가 아닐때만 query
    onError: (error) => {
      console.log("에러", error);
    },
```
- [x] location 수정을 위해 모달을 띄울때 input값이 ""인 경우 갑자기 모달이 닫혀서 안열리는 현상

기존코드
```js
  if (!locationSearch || !locationSearch.response) return <></>;

  const {
    response: { locations },
  } = locationSearch;
```
수정코드
```js
  const locations = locationSearch?.response?.locations ?? [];
```
- [x] 월간에서 suspense 삭제, 대신 totalCalendar get할때 refetch를 이용해서달력 delay 현상 조금 줄어들었지만.. 여전히 아쉬운 부분
```js
  // calendarData가 바뀔 때마다 useGetCalendar refetch
  useEffect(() => {
    refetchCalendarData();
  }, [calendarData, refetchCalendarData]);
```
- [x] 에러페이지 디자인
   - 랜딩페이지와 마찬가지로 디자인되었고 time만 설정되지 않은 정적인 페이지

- [x] EmojiDetailModal에서 partner도 이모지가 없으면 이름+프로필 아예 그 박스가 안보이게 refactor

- [ ] 로그인 후 아래 에러는 왜 해결이 안될까 ㅜ 배포 오류가 될것 같지는 않지만 고치고 싶다 ㅜ
<img width="339" alt="스크린샷 2024-07-29 오후 1 07 12" src="https://github.com/user-attachments/assets/16759395-e09e-4ada-8fc9-032ae2bcda4b">

## 다음에 할 것

- [ ] 디자인 QA
- [ ] 배포에러 잡기
