### PR TITLE
오늘 업로드, 로그인 전 403에러 해결

### DIFF
--- a/lubee/src/@common/hooks/useGetCouplesInfo.ts
+++ b/lubee/src/@common/hooks/useGetCouplesInfo.ts
@@ -1,8 +1,10 @@
 import { useQuery } from "react-query";
 import { getCouplesInfo } from "@common/api/getCouplesInfo";
 
-export function useGetCouplesInfo() {
+// isLoggedIn 기본값을 true로 설정
+export function useGetCouplesInfo(isLoggedIn: boolean = true) {
   const { data, isLoading, error } = useQuery("getCouplesInfo", getCouplesInfo, {
+    enabled: isLoggedIn, // isLoggedIn이 true일 때만 쿼리 실행
     onError: (error) => {
       console.log("에러 발생", error);
     },

--- a/lubee/src/home/today/components/ContentContainer.tsx
+++ b/lubee/src/home/today/components/ContentContainer.tsx
@@ -68,6 +68,7 @@ const Container = styled.section`
   display: flex;
   flex-direction: column;
   gap: 1.6rem;
+  min-height: 37rem;
 `;
 
 const CommentsContainer = styled.span`

--- a/lubee/src/home/today/components/TodayPicBox.tsx
+++ b/lubee/src/home/today/components/TodayPicBox.tsx
@@ -90,10 +90,11 @@ export default function TodayPicBox(props: TodayPicBoxProps) {
 
 const Container = styled.section`
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
   gap: 1.6rem;
+  align-items: start;
   width: 100%;
   height: 100%;
+  grid-template-columns: repeat(2, 1fr);
 `;
 
 const ImgContainer = styled.button`

--- a/lubee/src/home/today/components/Toggle.tsx
+++ b/lubee/src/home/today/components/Toggle.tsx
@@ -7,9 +7,12 @@ import { readPic } from "home/utils/readPic";
 interface ToggleProps {
   handleCalendar: () => void;
   showCalendar: boolean;
+  year: number;
+  month: number;
+  day: number;
 }
 export default function Toggle(props: ToggleProps) {
-  const { handleCalendar, showCalendar } = props;
+  const { handleCalendar, showCalendar, year, month, day } = props;
   const navigate = useNavigate();
 
   /* 사진 업로드 */
@@ -29,7 +32,7 @@ export default function Toggle(props: ToggleProps) {
       const reader = new FileReader();
       reader.readAsDataURL(picObj[0]);
       reader.onloadend = () => {
-        navigate("/upload", { state: { picSrc: picObj[0] } }); //useLocation 사용하기 위해 state 전달
+        navigate("/upload", { state: { picSrc: picObj[0], year: year, month: month, day: day } }); //useLocation 사용하기 위해 state 전달
       };
     }
   };

--- a/lubee/src/home/today/index.tsx
+++ b/lubee/src/home/today/index.tsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 import Toggle from "./components/Toggle";
 import ToggleCalendar from "./components/ToggleCalendar";
 import { useGetTodayHoney } from "home/hooks/useGetTodayHoney";
-import { getServerDate, getTodayDate, getTodayMonth } from "@common/utils/dateFormat";
+import { getServerDate, getTodayDate, getTodayMonth, getTodayYear } from "@common/utils/dateFormat";
 import ContentContainer from "./components/ContentContainer";
 import { useGetLoveDay } from "home/hooks/useGetLoveDay";
 import TodayHomeHeader from "./components/TodayHomeHeader";
@@ -56,7 +56,15 @@ export default function index() {
             {isPlusClicked ? <PlusClickedIcon /> : <PlusIcon />}
           </BtnWrapper>
         )}
-        {openToggle && <Toggle handleCalendar={handleCalendar} showCalendar={showCalendar} />}
+        {openToggle && (
+          <Toggle
+            handleCalendar={handleCalendar}
+            showCalendar={showCalendar}
+            year={getTodayYear}
+            month={getTodayMonth}
+            day={getTodayDate}
+          />
+        )}
         {showCalendar && <ToggleCalendar showCalendar={showCalendar} handleCalendar={handleCalendar} />}
       </Wrapper>
     </>

--- a/lubee/src/login/hooks/usePostLogin.ts
+++ b/lubee/src/login/hooks/usePostLogin.ts
@@ -8,6 +8,7 @@ import { useGetCouplesInfo } from "@common/hooks/useGetCouplesInfo";
 const usePostLogin = () => {
   const KAKAO_CODE = new URL(window.location.href).searchParams.get("code");
   const navigate = useNavigate();
+  // 여기서 useGetCouplesInfo를 호출하지 않고 useEffect로 로그인 요청이 완료된 후에 GetCouplesInfo를 호출
   const [isLoggedIn, setIsLoggedIn] = useState(false); // 로그인 상태를 추적
 
   useEffect(() => {

--- a/lubee/src/login/hooks/usePostLogin.ts
+++ b/lubee/src/login/hooks/usePostLogin.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "@common/api/api";
 import { loginErrorProps, loginResProps } from "login/types/loginProps";
@@ -8,7 +8,7 @@ import { useGetCouplesInfo } from "@common/hooks/useGetCouplesInfo";
 const usePostLogin = () => {
   const KAKAO_CODE = new URL(window.location.href).searchParams.get("code");
   const navigate = useNavigate();
-  const { data: couplesInfoResponse, isLoading, error } = useGetCouplesInfo();
+  const [isLoggedIn, setIsLoggedIn] = useState(false); // 로그인 상태를 추적
 
   useEffect(() => {
     if (KAKAO_CODE) {
@@ -17,6 +17,7 @@ const usePostLogin = () => {
         .then((res) => {
           const data = res.data as loginResProps; // AxiosResponse의 data를 loginResProps로 단언
           setToken(data.response.accessToken);
+          setIsLoggedIn(true); // 로그인 성공 시 상태 업데이트
           console.log("로그인 성공");
           console.log("로그인 데이터", data);
         })
@@ -34,6 +35,9 @@ const usePostLogin = () => {
   }, [KAKAO_CODE, navigate]);
 
   // 403에러 캐치해서 로딩페이지 띄우기
+  // useGetCouplesInfo 훅은 isLoggedIn이 true일 때만 쿼리를 실행
+  // 로그인 토큰이 설정된 이후에만 GetCouplesInfo API 호출을 해서 403 에러를 방지
+  const { data: couplesInfoResponse, isLoading, error } = useGetCouplesInfo(isLoggedIn); // 로그인 상태를 의존성으로 추가
 
   useEffect(() => {
     if (!isLoading && couplesInfoResponse) {


### PR DESCRIPTION
## Related Issues

- close #97 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 오류 수정

## 변경 사항 in Detail

- [x] 오늘에서 플러스 버튼을 통해 오늘 기록을 업로드할 때 에러 해결
  - home의 공통 컴포넌트 blankImgBtn의 코드와 비교해보니 날짜 전해주는 것이 없는 것 같아 추가했더니 해결됐어!

- [x] 로그인 성공하기 전에 GetCouplesInfo 403에러 해결
  - GetCouplesInfo에서 403 에러가 발생하는 이유는 콘솔로그 출력 순서를 보니까 아마도 로그인 토큰이 설정(콘솔로그로 로그인 성공이 출력)되기 전에 API 호출이 이루어지기 때문.. 그래서 로그인 요청이 완료되고, 토큰이 설정된 후에 로그인 여부 상태 업데이트하고 GetCouplesInfo를 호출하도록 순서를 조정했엉 
```
const usePostLogin = () => {
  const KAKAO_CODE = new URL(window.location.href).searchParams.get("code");
  const navigate = useNavigate();
  // 여기서 useGetCouplesInfo를 호출하지 않고 useEffect로 로그인 요청이 완료된 후에 GetCouplesInfo를 호출
  const [isLoggedIn, setIsLoggedIn] = useState(false); // 로그인 상태를 추적

  useEffect(() => {
    if (KAKAO_CODE) {
      api
        .post(`api/users/kakao/simpleLogin?code=${KAKAO_CODE}`)
        .then((res) => {
          const data = res.data as loginResProps; // AxiosResponse의 data를 loginResProps로 단언
          setToken(data.response.accessToken);
          setIsLoggedIn(true); // 로그인 성공 시 상태 업데이트
          console.log("로그인 성공");
          console.log("로그인 데이터", data);
        })
```
  - 그리고 useGetCouplesInfo를 호출할 때 isLoggedIn를 추가하여, 로그인 성공 후에만 GetCouplesInfo가 호출되도록 수정했어
`const { data: couplesInfoResponse, isLoading, error } = useGetCouplesInfo(isLoggedIn);`

  - react-query의 enabled 옵션으로 isLoggedIn이 만족될 때만 쿼리를 실행 가능하도록 useGetCouplesInfo이 isLoggedIn을 인자로 받아서 사용하도록 했어! 기본은 true로 해놔서 다른 데서 호출해서 쓸 때 isLoggedIn을 전달하지 않아도 쿼리가 실행되도록 했어!
```
// isLoggedIn 기본값을 true로 설정
export function useGetCouplesInfo(isLoggedIn: boolean = true) {
  const { data, isLoading, error } = useQuery("getCouplesInfo", getCouplesInfo, {
    enabled: isLoggedIn, // isLoggedIn이 true일 때만 쿼리 실행
    onError: (error) => {
      console.log("에러 발생", error);
    },
  });
  return { data, isLoading, error };
}
```



## 다음에 할 것

- [ ] 디자인 QA
