### PR TITLE
페이지네이션 할 때도 리액션 통신

### DIFF
--- a/lubee/src/@common/recoil/atom.ts
+++ b/lubee/src/@common/recoil/atom.ts
@@ -55,3 +55,10 @@ export const startDateState = atom<string>({
   key: "startDateState",
   default: "",
 });
+
+/* 이모지 저장 array*/
+
+export const emojiNumbersArrayState = atom<number[]>({
+  key: "emojiNumbersArray",
+  default: JSON.parse(sessionStorage.getItem("numbersArray") || "[]"),
+});

--- a/lubee/src/fullpic/components/FullpicHeader.tsx
+++ b/lubee/src/fullpic/components/FullpicHeader.tsx
@@ -24,8 +24,10 @@ export default function FullpicHeader(props: FullpicHeaderProps) {
   console.log("myEmoji", reaction_first);
 
   // 로컬 스토리지에서 배열 가져오기
-  const [numbersArray, setNumbersArray] = useState<number[]>(JSON.parse(localStorage.getItem("numbersArray") || "[]"));
-
+  const [numbersArray, setNumbersArray] = useState<number[]>(
+    JSON.parse(sessionStorage.getItem("numbersArray") || "[]"),
+  );
+  console.log("기존 배열", numbersArray);
   // 배열에 특정 숫자가 있는지 확인하는 함수
   function isNumberInArray(number: number): boolean {
     return numbersArray.includes(number);
@@ -35,7 +37,7 @@ export default function FullpicHeader(props: FullpicHeaderProps) {
 
   useEffect(() => {
     // 배열을 다시 로컬 스토리지에 저장
-    localStorage.setItem("numbersArray", JSON.stringify(numbersArray));
+    sessionStorage.setItem("numbersArray", JSON.stringify(numbersArray));
     console.log("업데이트 배열:", numbersArray);
   }, [numbersArray]);
 
@@ -51,7 +53,7 @@ export default function FullpicHeader(props: FullpicHeaderProps) {
               const updatedArray = [...numbersArray, memory_id];
               setNumbersArray(updatedArray);
               // 로컬 스토리지에 업데이트된 배열 저장
-              localStorage.setItem("numbersArray", JSON.stringify(updatedArray));
+              sessionStorage.setItem("numbersArray", JSON.stringify(updatedArray));
               // 페이지 이동
               if (prevPage === "today") {
                 navigate("/home/today");

--- a/lubee/src/fullpic/components/FullpicHeader.tsx
+++ b/lubee/src/fullpic/components/FullpicHeader.tsx
@@ -4,7 +4,9 @@ import { usePostReaction } from "@common/hooks/usePostReaction";
 import { BtnWrapper } from "@styles/btnStyle";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { emojiNumbersArrayState } from "@common/recoil/atom";
 
 interface FullpicHeaderProps {
   handleTrashBtn: (open: boolean) => void;
@@ -23,11 +25,10 @@ export default function FullpicHeader(props: FullpicHeaderProps) {
 
   console.log("myEmoji", reaction_first);
 
-  // 로컬 스토리지에서 배열 가져오기
-  const [numbersArray, setNumbersArray] = useState<number[]>(
-    JSON.parse(sessionStorage.getItem("numbersArray") || "[]"),
-  );
+  //recoil로 기존 array를 sessionstorage에서 가져오기
+  const [numbersArray, setNumbersArray] = useRecoilState(emojiNumbersArrayState);
   console.log("기존 배열", numbersArray);
+
   // 배열에 특정 숫자가 있는지 확인하는 함수
   function isNumberInArray(number: number): boolean {
     return numbersArray.includes(number);
@@ -36,7 +37,7 @@ export default function FullpicHeader(props: FullpicHeaderProps) {
   const prevPage = localStorage.getItem("currentPage");
 
   useEffect(() => {
-    // 배열을 다시 로컬 스토리지에 저장
+    // 배열을 다시 세션 스토리지에 저장
     sessionStorage.setItem("numbersArray", JSON.stringify(numbersArray));
     console.log("업데이트 배열:", numbersArray);
   }, [numbersArray]);

--- a/lubee/src/home/utils/readPic.ts
+++ b/lubee/src/home/utils/readPic.ts
@@ -1,5 +1,3 @@
-import { infoToast } from "@common/utils/toast";
-
 export interface readPicProps {
   input: FileList | null;
   setPicSrc: React.Dispatch<React.SetStateAction<File | undefined>>;
@@ -15,6 +13,5 @@ export const readPic = ({ input, setPicSrc, setVerified }: readPicProps) => {
     reader.readAsDataURL(input[0]);
     setPicSrc(input[0]);
     setVerified(false);
-    infoToast("사진 등록 성공");
   }
 };


### PR DESCRIPTION
## Related Issues

- close #102 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 주석 추가 및 수정

## 변경 사항 in Detail

- [x] 리액션 post, update

기존 
뒤로가기 버튼에만 통신
헤더에서만 리액션 통신이 필요해서 array를 **헤더에서 선언**
```js
  const [numbersArray, setNumbersArray] = useState<number[]>(JSON.parse(localStorage.getItem("numbersArray") || "[]"));
```

수정
뒤로가기 버튼 + 페이지네이션 버튼에도 통신
헤더+부모 component 둘 다  array가 필요하므로 **recoil로 관리**
```js
export const emojiNumbersArrayState = atom<number[]>({
  key: "emojiNumbersArray",
  default: JSON.parse(sessionStorage.getItem("numbersArray") || "[]"),
});
```

페이지를 넘겨도 리액션이 저장되는 것 확인 가능

https://github.com/user-attachments/assets/ad6c1ad0-2aa9-4361-92e3-d3a23f7a7fee




## 다음에 할 것

- [x] #101
